### PR TITLE
Feat/mg

### DIFF
--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,12,0,1
+#define CIOT_VER 0,12,0,2
 #define CIOT_IFACE_CFG_FILENAME "cfg%d.dat"
 
 #if defined(CIOT_TARGET_WIN) || defined(CIOT_TARGET_LINUX)

--- a/src/linux/ciot_wifi.c
+++ b/src/linux/ciot_wifi.c
@@ -131,14 +131,4 @@ ciot_err_t ciot_wifi_scan(ciot_wifi_t self)
     return CIOT_ERR_NOT_SUPPORTED;
 }
 
-ciot_err_t ciot_wifi_get_scanned_ap(ciot_wifi_t self, int id, ciot_wifi_ap_info_t *ap_info)
-{
-    return CIOT_ERR_NOT_SUPPORTED;
-}
-
-ciot_err_t ciot_wifi_get_scanned_aps(ciot_wifi_t self, ciot_wifi_ap_list_t *ap_list)
-{
-    return CIOT_ERR_NOT_SUPPORTED;
-}
-
 #endif // CIOT_CONFIG_FEATURE_WIFI == 1


### PR DESCRIPTION
This pull request contains minor updates focused on versioning and code cleanup for WiFi-related functions in the Linux implementation.

Versioning:

* Updated the project version number in `ciot.h` from `0,12,0,1` to `0,12,0,2` to reflect the latest changes.

WiFi code cleanup:

* Removed stub implementations for WiFi access point scanning functions (`ciot_wifi_get_scanned_ap` and `ciot_wifi_get_scanned_aps`) from `ciot_wifi.c`, which previously just returned `CIOT_ERR_NOT_SUPPORTED`.