### PR TITLE
Feat/proxy

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -50,3 +50,14 @@ This can be achieved adding an proxy configuration to the message sent by ciot a
     }
 }
 ```
+
+### Fix
+
+**MQTT**
+
+* Fix esp32 MQTT_EVENT_DATA ciot event type
+
+**BLE Scanner**
+
+* Fix data tag type on ciot_ble_scn_get_data function at ciot_ble_scn_base
+

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,13,0,0
+#define CIOT_VER 0,13,1,0
 #define CIOT_IFACE_CFG_FILENAME "cfg%d.dat"
 
 #if defined(CIOT_TARGET_WIN) || defined(CIOT_TARGET_LINUX)

--- a/src/common/ciot_ble_scn_base.c
+++ b/src/common/ciot_ble_scn_base.c
@@ -75,7 +75,7 @@ static ciot_err_t ciot_ble_scn_get_data(ciot_iface_t *iface, ciot_msg_data_t *da
 
     ciot_ble_scn_base_t *self = iface->ptr;
     ciot_data_type_t data_type = data->get_data.type;
-    data->which_type = CIOT_MSG_DATA_BLE_TAG;
+    data->which_type = CIOT_MSG_DATA_BLE_SCN_TAG;
 
     switch (data_type)
     {

--- a/src/esp32/ciot_mqtt_client.c
+++ b/src/esp32/ciot_mqtt_client.c
@@ -169,7 +169,7 @@ static void ciot_mqtt_event_handler(void *handler_args, esp_event_base_t event_b
         ESP_LOGI(TAG, "MQTT_EVENT_DATA");
         if(base->process_all_topics || strncmp(mqtt_event->topic, base->cfg.topics.sub, mqtt_event->topic_len) == 0)
         {
-            event.type = CIOT_EVENT_TYPE_REQUEST;
+            event.type = CIOT_EVENT_TYPE_MSG;
             event.raw.size = mqtt_event->data_len;
             memcpy(event.raw.bytes, (uint8_t*)mqtt_event->data, mqtt_event->data_len);
             ciot_iface_send_event(&base->iface, &event);


### PR DESCRIPTION
This pull request includes a patch release update and two important bug fixes related to MQTT event handling and BLE scanner data tagging. The changes address event type correctness in the MQTT client on ESP32 and ensure the correct data tag is used in the BLE scanner base code.

Version update:

* Bump version to `0.13.1.0` in `ciot.h` to reflect the new patch release.

Bug fixes:

**MQTT**

* Fix the event type for `MQTT_EVENT_DATA` in the ESP32 MQTT client to use `CIOT_EVENT_TYPE_MSG` instead of `CIOT_EVENT_TYPE_REQUEST`. [[1]](diffhunk://#diff-f8eaf168fd7e70a563ff15acc977930908baa391c7a476f3d605cf857af68974L172-R172) [[2]](diffhunk://#diff-0541a2b7e298ac99ae17f17d35f0e8435e2b998bbefcb7a3cf6db8b511746db9R53-R63)

**BLE Scanner**

* Correct the data tag type in the `ciot_ble_scn_get_data` function to use `CIOT_MSG_DATA_BLE_SCN_TAG` instead of `CIOT_MSG_DATA_BLE_TAG`. [[1]](diffhunk://#diff-1d56b9dfd453aa5d1584b74b104467528a195ea593194e1b200838f769b93ea2L78-R78) [[2]](diffhunk://#diff-0541a2b7e298ac99ae17f17d35f0e8435e2b998bbefcb7a3cf6db8b511746db9R53-R63)