### PR TITLE
Stable release

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -50,3 +50,14 @@ This can be achieved adding an proxy configuration to the message sent by ciot a
     }
 }
 ```
+
+### Fix
+
+**MQTT**
+
+* Fix esp32 MQTT_EVENT_DATA ciot event type
+
+**BLE Scanner**
+
+* Fix data tag type on ciot_ble_scn_get_data function at ciot_ble_scn_base
+

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,13,0,0
+#define CIOT_VER 0,13,1,0
 #define CIOT_IFACE_CFG_FILENAME "cfg%d.dat"
 
 #if defined(CIOT_TARGET_WIN) || defined(CIOT_TARGET_LINUX)

--- a/src/common/ciot_ble_scn_base.c
+++ b/src/common/ciot_ble_scn_base.c
@@ -75,7 +75,7 @@ static ciot_err_t ciot_ble_scn_get_data(ciot_iface_t *iface, ciot_msg_data_t *da
 
     ciot_ble_scn_base_t *self = iface->ptr;
     ciot_data_type_t data_type = data->get_data.type;
-    data->which_type = CIOT_MSG_DATA_BLE_TAG;
+    data->which_type = CIOT_MSG_DATA_BLE_SCN_TAG;
 
     switch (data_type)
     {

--- a/src/esp32/ciot_mqtt_client.c
+++ b/src/esp32/ciot_mqtt_client.c
@@ -169,7 +169,7 @@ static void ciot_mqtt_event_handler(void *handler_args, esp_event_base_t event_b
         ESP_LOGI(TAG, "MQTT_EVENT_DATA");
         if(base->process_all_topics || strncmp(mqtt_event->topic, base->cfg.topics.sub, mqtt_event->topic_len) == 0)
         {
-            event.type = CIOT_EVENT_TYPE_REQUEST;
+            event.type = CIOT_EVENT_TYPE_MSG;
             event.raw.size = mqtt_event->data_len;
             memcpy(event.raw.bytes, (uint8_t*)mqtt_event->data, mqtt_event->data_len);
             ciot_iface_send_event(&base->iface, &event);


### PR DESCRIPTION
This pull request includes a version bump and several targeted bug fixes for the MQTT and BLE Scanner components. The most significant changes address incorrect event and data tag types, ensuring that the system processes messages and BLE scan data accurately.

**Bug fixes:**

* MQTT:
  - Fixed the event type for `MQTT_EVENT_DATA` to use `CIOT_EVENT_TYPE_MSG` instead of `CIOT_EVENT_TYPE_REQUEST` in `ciot_mqtt_client.c`.

* BLE Scanner:
  - Corrected the data tag type assignment to use `CIOT_MSG_DATA_BLE_SCN_TAG` in `ciot_ble_scn_base.c`.

**Version update:**

* Updated the version macro in `ciot.h` from `0,13,0,0` to `0,13,1,0`.

**Documentation:**

* Added a summary of the above fixes in `changes.md`.