### PR TITLE
Develop

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,10 +2,10 @@
 
 ### Changes
 
-**Error handling improvements:**
+**Proxy request handling improvements:**
 
-* Added a new macro `CIOT_ERR_MEMORY_CHECK` in `ciot_err.h` to standardize and simplify memory allocation error checking throughout the codebase.
+* Added a new condition in `ciot_busy_task` (in `ciot.c`) to save interface configuration data when a proxy request with `save` set to true is received. This involves generating a filename, saving the data to storage, updating the proxy state, sending a response, and logging the operation.
 
-**Memory management and function refactoring:**
+**Minor formatting fix:**
 
-* Refactored the `ciot_save_cfg` function in `ciot.c` to allocate the `ciot_msg_t` structure dynamically using `calloc`, apply the new memory check macro, and ensure the allocated memory is freed after use. This reduces stack usage and improves robustness against memory allocation failures.
+* Moved the `#endif // CONFIG_ESP_HTTPS_OTA_DECRYPT_CB` directive to after the function declaration in `ciot_ota.c` to correctly scope conditional compilation.

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,14,0,0
+#define CIOT_VER 0,15,0,0
 #define CIOT_IFACE_CFG_FILENAME "cfg%d.dat"
 
 #if defined(CIOT_TARGET_WIN) || defined(CIOT_TARGET_LINUX)

--- a/src/core/ciot.c
+++ b/src/core/ciot.c
@@ -417,7 +417,15 @@ static ciot_err_t ciot_busy_task(ciot_t self)
         {
             if(event->msg.type == CIOT_MSG_TYPE_REQUEST)
             {
-                if(event->msg.has_proxy == true && event->msg.proxy.state == CIOT_PROXY_STATE_PENDING)
+                if(event->msg.has_proxy == true && ciot_iface_is_equal(&self->iface.info, &event->msg.proxy.iface) && ciot_iface_is_equal(&self->ifaces.list[event->msg.iface.id]->info, &event->msg.iface) && event->msg.proxy.save) {
+                    char filename[16];
+                    sprintf(filename, CIOT_IFACE_CFG_FILENAME, (int)event->msg.iface.id);
+                    event->msg.error = ciot_storage_save_data(self->storage, filename, &event->msg.data);
+                    event->msg.proxy.state = CIOT_PROXY_STATE_PROXY_STATE_SENT;
+                    ciot_iface_send_rsp(sender, &event->msg);
+                    CIOT_LOGI(TAG, "%s config saved", ciot_iface_to_str(self->ifaces.list[event->msg.iface.id]));
+                }
+                else if(event->msg.has_proxy == true && event->msg.proxy.state == CIOT_PROXY_STATE_PENDING)
                 {
                     // Proxy request handling
                     CIOT_LOGI(TAG, "Processing proxy request from %s", ciot_iface_to_str(sender));

--- a/src/esp32/ciot_ota.c
+++ b/src/esp32/ciot_ota.c
@@ -51,8 +51,8 @@ static void __attribute__((noreturn)) ciot_ota_task_fatal_error(ciot_ota_t self)
 static void ciot_ota_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data);
 #ifdef CONFIG_ESP_HTTPS_OTA_DECRYPT_CB
 static esp_err_t ciot_ota_decrypt_cb(decrypt_cb_arg_t *args, void *user_ctx);
-#endif // CONFIG_ESP_HTTPS_OTA_DECRYPT_CB
 static esp_err_t ciot_ota_validate_image_header(esp_app_desc_t *new_app_info, bool force);
+#endif // CONFIG_ESP_HTTPS_OTA_DECRYPT_CB
 
 static const char *TAG = "ciot_ota";
 


### PR DESCRIPTION
This pull request focuses on improving how proxy requests are handled in the CIOT system, specifically for saving interface configuration data. It also includes a minor formatting fix and a version bump. The most important changes are grouped below:

**Proxy request handling improvements:**

* Added logic in `ciot_busy_task` (`ciot.c`) to handle proxy requests with `save` set to true: generates a filename, saves configuration data to storage, updates proxy state, sends a response, and logs the operation.

**Version update:**

* Updated the CIOT version number from `0,14,0,0` to `0,15,0,0` in `include/ciot.h`.

**Minor formatting fix:**

* Moved the `#endif // CONFIG_ESP_HTTPS_OTA_DECRYPT_CB` directive to after the function declaration in `ciot_ota.c` for correct conditional compilation scope.