### PR TITLE
Feat/v16

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,10 +2,24 @@
 
 ### Changes
 
-**Proxy request handling improvements:**
+**HTTP Server Customization:**
 
-* Added a new condition in `ciot_busy_task` (in `ciot.c`) to save interface configuration data when a proxy request with `save` set to true is received. This involves generating a filename, saving the data to storage, updating the proxy state, sending a response, and logging the operation.
+* Added support for registering custom API endpoints in the HTTP server, including a new handler type (`ciot_http_server_custom_api_handler_fn`), associated data structures, and the ability to enable/disable and handle custom routes at runtime. This allows users to define and process their own HTTP API endpoints through the CIOT HTTP server. [[1]](diffhunk://#diff-30be0adb0cad3dca9597199fc8e81a0da02c60e787a149fc2f378b9ea209fc1cR24-R25) [[2]](diffhunk://#diff-30be0adb0cad3dca9597199fc8e81a0da02c60e787a149fc2f378b9ea209fc1cR43-R57) [[3]](diffhunk://#diff-30be0adb0cad3dca9597199fc8e81a0da02c60e787a149fc2f378b9ea209fc1cR69) [[4]](diffhunk://#diff-c177ce0c72f538dbaee642d82ed4a16a68060a6fc05da2b6932c167920cea1f7L26-R31) [[5]](diffhunk://#diff-c177ce0c72f538dbaee642d82ed4a16a68060a6fc05da2b6932c167920cea1f7R49-R57) [[6]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692L36-R39) [[7]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692L59-R60) [[8]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692L96-R97) [[9]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692R108-R129) [[10]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692L121-R140) [[11]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692L169-R188) [[12]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692R293-R361)
 
-**Minor formatting fix:**
+**Network Interface Enhancements:**
 
-* Moved the `#endif // CONFIG_ESP_HTTPS_OTA_DECRYPT_CB` directive to after the function declaration in `ciot_ota.c` to correctly scope conditional compilation.
+* Added new APIs to retrieve the current IP address for both Ethernet (`ciot_eth_get_ip`) and WiFi (`ciot_wifi_get_ip`) interfaces, as well as to query the WiFi signal strength (`ciot_wifi_get_rssi`). These changes are implemented in both the interface headers and their respective source files. [[1]](diffhunk://#diff-fa4523ff179274410ba9796738b1f504e59afa76563a8ee1b0afabb9a6ce640eR37) [[2]](diffhunk://#diff-10c27a04ab9edf24529f28f38b31250b422c7699ec0d9c9a1a1c7fae81747629R140-R149) [[3]](diffhunk://#diff-ca06c9e501fbf825c6fd9ca3cd0cce0ce9db4ddb5c48c00c94d2c023ccb800d0R60-R61) [[4]](diffhunk://#diff-eef672241b635d4c1209cc3ad8db038d86150871db5b6aaf036ec69d255125d5R158-R166) [[5]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279R171-R180)
+* The WiFi status retrieval now includes the latest RSSI value, and WiFi connection events update the RSSI and access point information. [[1]](diffhunk://#diff-eef672241b635d4c1209cc3ad8db038d86150871db5b6aaf036ec69d255125d5R135) [[2]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279R408-R413)
+
+**DFU (Device Firmware Update) Improvements:**
+
+* Added a "test mode" to the Nordic DFU implementation, including new struct members, API (`ciot_dfu_nrf_set_test_mode`), and logic to immediately complete ping responses and state transitions when in test mode. [[1]](diffhunk://#diff-74a286d93b9147cda2e796082ebafd561f5ffe864b6e7ef62c25a6043764bb84R102) [[2]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793L63-R63) [[3]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R95-R96) [[4]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R134-R140) [[5]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R463-R468)
+* Improved logging for DFU events and start operations. [[1]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R95-R96) [[2]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793L588-R603)
+
+**Core CIOT API Additions:**
+
+* Introduced a new function (`ciot_iface_get_state`) to query the state of a specific interface by ID, with corresponding header and implementation updates. [[1]](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554R111) [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10R666-R672)
+
+**Miscellaneous:**
+
+* Minor improvements to event handling and logging, such as restoring event types after sending responses.

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,15,0,0
+#define CIOT_VER 0,16,0,0
 #define CIOT_IFACE_CFG_FILENAME "cfg%d.dat"
 
 #if defined(CIOT_TARGET_WIN) || defined(CIOT_TARGET_LINUX)

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -108,5 +108,6 @@ ciot_err_t ciot_get_ifaces_info(ciot_t self, ciot_info_t *info);
 ciot_err_t ciot_delete_all(ciot_t self);
 bool ciot_cfg_exists(ciot_t self, uint8_t iface_id);
 const char *ciot_event_to_str(ciot_event_t *event);
+ciot_iface_state_t ciot_iface_get_state(ciot_t self, uint16_t iface_id);
 
 #endif  //!__CIOT__H__

--- a/include/ciot_dfu_nrf.h
+++ b/include/ciot_dfu_nrf.h
@@ -99,6 +99,7 @@ typedef struct ciot_dfu_nrf *ciot_dfu_nrf_t;
 ciot_dfu_nrf_t ciot_dfu_nrf_new(ciot_dfu_nrf_cfg_t *cfg);
 ciot_err_t ciot_dfu_nrf_start(ciot_dfu_nrf_t self, ciot_dfu_cfg_t *cfg);
 ciot_err_t ciot_dfu_nrf_stop(ciot_dfu_nrf_t self);
+ciot_err_t ciot_dfu_nrf_set_test_mode(ciot_dfu_nrf_t self, bool enable);
 ciot_err_t ciot_dfu_nrf_init(ciot_dfu_nrf_t self);
 ciot_err_t ciot_dfu_nrf_process_req(ciot_dfu_nrf_t self, ciot_dfu_req_t *req);
 ciot_err_t ciot_dfu_nrf_get_cfg(ciot_dfu_nrf_t self, ciot_dfu_cfg_t *cfg);

--- a/include/ciot_eth.h
+++ b/include/ciot_eth.h
@@ -34,5 +34,6 @@ ciot_err_t ciot_eth_get_cfg(ciot_eth_t self, ciot_tcp_cfg_t *cfg);
 ciot_err_t ciot_eth_get_status(ciot_eth_t self, ciot_tcp_status_t *status);
 ciot_err_t ciot_eth_get_info(ciot_eth_t self, ciot_tcp_info_t *info);
 ciot_err_t ciot_eth_get_mac(ciot_eth_t self, uint8_t mac[6]);
+ciot_err_t ciot_eth_get_ip(ciot_eth_t self, uint8_t ip[4]);
 
 #endif  //!__CIOT_ETH__H__

--- a/include/ciot_http_server.h
+++ b/include/ciot_http_server.h
@@ -21,6 +21,8 @@ extern "C" {
 
 typedef struct ciot_http_server *ciot_http_server_t;
 
+typedef ciot_err_t (ciot_http_server_custom_api_handler_fn)(ciot_http_server_t self, const char *uri, size_t uri_len, char *method, uint8_t *data, size_t size, void *args);
+
 #ifndef CIOT_CONFIG_URL_SIZE
 #define CIOT_CONFIG_URL_SIZE 48
 #endif
@@ -38,12 +40,21 @@ typedef struct ciot_http_server_homepage_cfg
     size_t size;
 } ciot_http_server_homepage_cfg_t;
 
+typedef struct ciot_http_server_custom_api
+{
+    bool enabled;
+    const char *uri;
+    ciot_http_server_custom_api_handler_fn *handler;
+    void *args;
+} ciot_http_server_custom_api_t;
+
 typedef struct ciot_http_server_base
 {
     ciot_iface_t iface;
     ciot_http_server_cfg_t cfg;
     ciot_http_server_status_t status;
     ciot_http_server_homepage_cfg_t homepage;
+    ciot_http_server_custom_api_t custom_api;
 } ciot_http_server_base_t;
 
 ciot_http_server_t ciot_http_server_new(void *handle);
@@ -55,6 +66,7 @@ ciot_err_t ciot_http_server_get_cfg(ciot_http_server_t self, ciot_http_server_cf
 ciot_err_t ciot_http_server_get_status(ciot_http_server_t self, ciot_http_server_status_t *status);
 ciot_err_t ciot_http_server_send_bytes(ciot_http_server_t self, uint8_t *data, int size);
 ciot_err_t ciot_http_server_set_homepage(ciot_http_server_t self, ciot_http_server_homepage_cfg_t *homepage);
+ciot_err_t ciot_http_server_set_custom_api(ciot_http_server_t self, ciot_http_server_custom_api_t *custom_api);
 
 #ifdef __cplusplus
 }

--- a/include/ciot_wifi.h
+++ b/include/ciot_wifi.h
@@ -57,6 +57,8 @@ ciot_err_t ciot_wifi_toggle(ciot_wifi_t self);
 ciot_err_t ciot_wifi_scan(ciot_wifi_t self);
 ciot_err_t ciot_wifi_get_scanned_ap(ciot_wifi_t self, int id, ciot_wifi_ap_info_t *ap_info);
 ciot_err_t ciot_wifi_get_scanned_aps(ciot_wifi_t self, ciot_wifi_ap_list_t *ap_list);
+ciot_err_t ciot_wifi_get_ip(ciot_wifi_t self, uint8_t ip[4]);
+ciot_err_t ciot_wifi_get_rssi(ciot_wifi_t self, int32_t *rssi);
 
 #ifdef __cplusplus
 }

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "ciot_c",
-    "version": "0.12.0",
+    "version": "0.16.0",
     "description": "Library for IoT projects",
     "keywords": ["IoT", "Automation", "TA"],
     "repository":

--- a/src/common/ciot_dfu_nrf.c
+++ b/src/common/ciot_dfu_nrf.c
@@ -60,7 +60,7 @@ struct ciot_dfu_nrf
     uint32_t data_transferred;
     ciot_dfu_nrf_object_t object;
     bool ping_refused;
-
+    bool test_mode;
     uint64_t timer;
 };
 
@@ -91,6 +91,8 @@ ciot_err_t ciot_dfu_nrf_start(ciot_dfu_nrf_t self, ciot_dfu_cfg_t *cfg)
 {
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_STATE_CHECK(self->base.status.state, CIOT_DFU_STATE_IDLE);
+
+    CIOT_LOGI(TAG, "Starting DFU nrf...");
 
     if (cfg->type != self->cfg.dfu.type)
     {
@@ -126,6 +128,13 @@ ciot_err_t ciot_dfu_nrf_stop(ciot_dfu_nrf_t self)
         .common.stop = true,
     };
     self->cfg.iface->process_data(self->cfg.iface, &data);
+    return CIOT_ERR_OK;
+}
+
+ciot_err_t ciot_dfu_nrf_set_test_mode(ciot_dfu_nrf_t self, bool enable)
+{
+    CIOT_ERR_NULL_CHECK(self);
+    self->test_mode = enable;
     return CIOT_ERR_OK;
 }
 
@@ -451,6 +460,12 @@ static ciot_err_t ciot_dfu_nrf_process_response(ciot_dfu_nrf_t self, uint8_t *da
         data[2] == CIOT_DFU_NRF_RES_CODE_SUCCESS)
     {
         CIOT_LOGI(TAG, "Ping response sucess");
+        if (self->test_mode)
+        {
+            self->state = CIOT_DFU_NRF_STATE_COMPLETED;
+            ciot_dfu_nrf_set_state(self, CIOT_DFU_STATE_COMPLETED);
+            return CIOT_ERR_OK;
+        }
         self->state = CIOT_DFU_NRF_STATE_CREATE_OBJECT;
         ciot_dfu_nrf_set_state(self, CIOT_DFU_STATE_IN_PROGRESS);
         return CIOT_ERR_OK;
@@ -585,7 +600,7 @@ static ciot_err_t ciot_dfu_nrf_set_state(ciot_dfu_nrf_t self, ciot_dfu_state_t s
 
 static ciot_err_t ciot_dfu_nrf_event_handler(ciot_iface_t *sender, ciot_event_t *event, void *args)
 {
-    CIOT_LOGD(TAG, "Event received %s", ciot_event_to_str(event));
+    CIOT_LOGI(TAG, "Event received %s", ciot_event_to_str(event));
 
     ciot_dfu_nrf_t self = (ciot_dfu_nrf_t)args;
 

--- a/src/common/ciot_eth_base.c
+++ b/src/common/ciot_eth_base.c
@@ -137,4 +137,14 @@ ciot_err_t ciot_eth_get_mac(ciot_eth_t self, uint8_t mac[6])
     return CIOT_ERR_OK;
 }
 
+ciot_err_t ciot_eth_get_ip(ciot_eth_t self, uint8_t ip[4])
+{
+    CIOT_ERR_NULL_CHECK(self);
+    CIOT_ERR_NULL_CHECK(ip);
+    ciot_eth_base_t *base = (ciot_eth_base_t*)self;
+    ciot_tcp_base_t *tcp = (ciot_tcp_base_t*)base->tcp;
+    memcpy(ip, tcp->info->ip, 4);
+    return CIOT_ERR_OK;
+}
+
 #endif // CIOT_CONFIG_FEATURE_ETH == 1

--- a/src/common/ciot_http_server_base.c
+++ b/src/common/ciot_http_server_base.c
@@ -23,12 +23,12 @@ static ciot_err_t ciot_http_server_send_data(ciot_iface_t *iface, uint8_t *data,
 ciot_err_t ciot_http_server_init(ciot_http_server_t self)
 {
     ciot_http_server_base_t *base = (ciot_http_server_base_t *)self;
-
     base->iface.ptr = self;
     base->iface.process_data = ciot_http_server_process_data;
     base->iface.get_data = ciot_http_server_get_data;
     base->iface.send_data = ciot_http_server_send_data;
     base->iface.info.type = CIOT_IFACE_TYPE_HTTP_SERVER;
+    base->custom_api.enabled = false;
     return CIOT_ERR_OK;
 }
 
@@ -43,6 +43,15 @@ ciot_err_t ciot_http_server_set_homepage(ciot_http_server_t self, ciot_http_serv
 {
     ciot_http_server_base_t *base = (ciot_http_server_base_t *)self;
     base->homepage = *homepage;
+    return CIOT_ERR_OK;
+}
+
+ciot_err_t ciot_http_server_set_custom_api(ciot_http_server_t self, ciot_http_server_custom_api_t *custom_api)
+{
+    CIOT_ERR_NULL_CHECK(self);
+    CIOT_ERR_NULL_CHECK(custom_api);
+    ciot_http_server_base_t *base = (ciot_http_server_base_t *)self;
+    base->custom_api = *custom_api;
     return CIOT_ERR_OK;
 }
 

--- a/src/common/ciot_wifi_base.c
+++ b/src/common/ciot_wifi_base.c
@@ -132,6 +132,7 @@ ciot_err_t ciot_wifi_get_status(ciot_wifi_t self, ciot_wifi_status_t *status)
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(status);
     ciot_wifi_base_t *base = (ciot_wifi_base_t*)self;
+    ciot_wifi_get_rssi(self, &base->status.rssi);
     *status = base->status;
     return CIOT_ERR_OK;
 }
@@ -151,6 +152,15 @@ ciot_err_t ciot_wifi_get_mac(ciot_wifi_t self, uint8_t mac[6])
     CIOT_ERR_NULL_CHECK(mac);
     ciot_wifi_base_t *base = (ciot_wifi_base_t*)self;
     memcpy(mac, base->info.tcp.mac, 6);
+    return CIOT_ERR_OK;
+}
+
+ciot_err_t ciot_wifi_get_ip(ciot_wifi_t self, uint8_t ip[4])
+{
+    CIOT_ERR_NULL_CHECK(self);
+    CIOT_ERR_NULL_CHECK(ip);
+    ciot_wifi_base_t *base = (ciot_wifi_base_t*)self;
+    memcpy(ip, base->info.tcp.ip, 4);
     return CIOT_ERR_OK;
 }
 

--- a/src/core/ciot.c
+++ b/src/core/ciot.c
@@ -661,3 +661,10 @@ static ciot_err_t ciot_bytes_received(ciot_t self, ciot_iface_t *sender, uint8_t
         return CIOT_ERR_OK;
     }
 }
+
+ciot_iface_state_t ciot_iface_get_state(ciot_t self, uint16_t iface_id)
+{
+    CIOT_ERR_NULL_CHECK(self);
+    CIOT_ERR_ID_CHECK(iface_id, self->ifaces.count);
+    return self->status.ifaces[iface_id].state;
+}

--- a/src/core/ciot.c
+++ b/src/core/ciot.c
@@ -402,9 +402,11 @@ static ciot_err_t ciot_busy_task(ciot_t self)
             // else
             // {
                 CIOT_LOGI(TAG, "Response sended");
+                ciot_event_type_t prev_type = event->type;
                 event->msg.id = sender->req_status.id;
                 event->type = CIOT_EVENT_TYPE_DONE;
                 ciot_iface_send_rsp(self->ifaces.list[sender->req_status.iface.id], &event->msg);
+                event->type = prev_type;
             // }
             sender->req_status.state = CIOT_IFACE_REQ_STATE_IDLE;
         }

--- a/src/default/ciot_wifi.c
+++ b/src/default/ciot_wifi.c
@@ -90,6 +90,11 @@ ciot_err_t ciot_wifi_send_bytes(ciot_iface_t *iface, uint8_t *bytes, int size)
     return CIOT_ERR_NOT_IMPLEMENTED;
 }
 
+ciot_err_t ciot_wifi_get_rssi(ciot_wifi_t self, int32_t *rssi)
+{
+    return CIOT_ERR_NOT_SUPPORTED;
+}
+
 static ciot_err_t ciot_wifi_set_cfg(ciot_wifi_t self, ciot_wifi_cfg_t *cfg)
 {
     CIOT_LOGI(TAG, "Configuring");

--- a/src/esp32/ciot_http_server.c
+++ b/src/esp32/ciot_http_server.c
@@ -33,9 +33,10 @@ struct ciot_http_server
 static const char *TAG = "ciot_http_server";
 
 static ciot_err_t ciot_https_register_routes(ciot_http_server_t self);
-static esp_err_t ciot_post_handler(httpd_req_t *req);
-static esp_err_t ciot_file_handler(httpd_req_t *req);
+static esp_err_t ciot_http_server_api_handler(httpd_req_t *req);
+static esp_err_t ciot_http_server_file_handler(httpd_req_t *req);
 static const char *get_mime_type(const char *filename);
+static esp_err_t ciot_http_server_custom_api_handler(httpd_req_t *req);
 
 ciot_http_server_t ciot_http_server_new(void *handle)
 {
@@ -56,7 +57,7 @@ ciot_err_t ciot_http_server_start(ciot_http_server_t self, ciot_http_server_cfg_
 
     httpd_config_t httpd_config = HTTPD_DEFAULT_CONFIG();
     httpd_config.server_port = cfg->port;
-    httpd_config.max_uri_handlers = 2;
+    httpd_config.max_uri_handlers = 3;
     httpd_config.uri_match_fn = httpd_uri_match_wildcard;
     httpd_config.stack_size = 8192;
 
@@ -93,7 +94,7 @@ static ciot_err_t ciot_https_register_routes(ciot_http_server_t self)
     CIOT_LOGI(TAG, "Registering route: %s", self->base.cfg.route);
     httpd_uri_t post_uri = {
         .uri = self->base.cfg.route,
-        .handler = ciot_post_handler,
+        .handler = ciot_http_server_api_handler,
         .method = HTTP_POST,
         .user_ctx = self,
     };
@@ -104,10 +105,28 @@ static ciot_err_t ciot_https_register_routes(ciot_http_server_t self)
         return CIOT_ERR_FAIL;
     }
 
+    if (self->base.custom_api.enabled && self->base.custom_api.handler != NULL)
+    {
+        CIOT_LOGI(TAG, "Registering route: %s", self->base.custom_api.uri);
+        httpd_uri_t post_uri = {
+            .uri = self->base.custom_api.uri,
+            .handler = ciot_http_server_custom_api_handler,
+            .method = HTTP_ANY,
+            .user_ctx = self,
+        };
+        esp_err_t err = httpd_register_uri_handler(self->handle, &post_uri);
+        if (err)
+        {
+            CIOT_LOGE(TAG, "Register uri error: %s", esp_err_to_name(err));
+            return CIOT_ERR_FAIL;
+        }
+    }
+
+    CIOT_LOGI(TAG, "Registering route: /*");
     httpd_uri_t file_uri = {
-        .uri = "/*", // Captura todas as URIs
+        .uri = "/*",
         .method = HTTP_GET,
-        .handler = ciot_file_handler,
+        .handler = ciot_http_server_file_handler,
         .user_ctx = self};
     err = httpd_register_uri_handler(self->handle, &file_uri);
     if (err)
@@ -118,7 +137,7 @@ static ciot_err_t ciot_https_register_routes(ciot_http_server_t self)
     return CIOT_ERR_OK;
 }
 
-static esp_err_t ciot_post_handler(httpd_req_t *req)
+static esp_err_t ciot_http_server_api_handler(httpd_req_t *req)
 {
     ciot_http_server_t self = (ciot_http_server_t)req->user_ctx;
     ciot_event_t event = {0};
@@ -166,7 +185,7 @@ static esp_err_t ciot_post_handler(httpd_req_t *req)
     return CIOT_ERR_OK;
 }
 
-static esp_err_t ciot_file_handler(httpd_req_t *req)
+static esp_err_t ciot_http_server_file_handler(httpd_req_t *req)
 {
     ciot_http_server_t self = (ciot_http_server_t)req->user_ctx;
 
@@ -176,7 +195,7 @@ static esp_err_t ciot_file_handler(httpd_req_t *req)
 
     if (((strcmp(req->uri, "/") == 0) || (strcmp(req->uri, "/index.html") == 0)) && self->base.homepage.size > 0)
     {
-        if(self->base.homepage.gz)
+        if (self->base.homepage.gz)
         {
             CIOT_LOGI(TAG, "Serving embed gzip");
             httpd_resp_set_hdr(req, "Content-Encoding", "gzip");
@@ -269,6 +288,75 @@ static const char *get_mime_type(const char *filename)
     if (strstr(filename, ".svg"))
         return "image/svg+xml";
     return "text/plain";
+}
+
+static esp_err_t ciot_http_server_custom_api_handler(httpd_req_t *req)
+{
+    ciot_http_server_t self = (ciot_http_server_t)req->user_ctx;
+    ciot_event_t event = {0};
+
+    if (self == NULL)
+    {
+        CIOT_LOGE(TAG, "Null context");
+        return ESP_FAIL;
+    }
+
+    httpd_req_recv(req, (char *)event.raw.bytes, req->content_len);
+
+    switch (req->method)
+    {
+    case HTTP_DELETE:
+        self->base.custom_api.handler(self, req->uri, strlen(req->uri), "DELETE", event.raw.bytes, req->content_len, self->base.custom_api.args);
+        break;
+    case HTTP_GET:
+        self->base.custom_api.handler(self, req->uri, strlen(req->uri), "GET", event.raw.bytes, req->content_len, self->base.custom_api.args);
+        break;
+    case HTTP_HEAD:
+        self->base.custom_api.handler(self, req->uri, strlen(req->uri), "HEAD", event.raw.bytes, req->content_len, self->base.custom_api.args);
+        break;
+    case HTTP_POST:
+        self->base.custom_api.handler(self, req->uri, strlen(req->uri), "POST", event.raw.bytes, req->content_len, self->base.custom_api.args);
+        break;
+    case HTTP_PUT:
+        self->base.custom_api.handler(self, req->uri, strlen(req->uri), "PUT", event.raw.bytes, req->content_len, self->base.custom_api.args);
+        break;
+    case HTTP_CONNECT:
+        self->base.custom_api.handler(self, req->uri, strlen(req->uri), "CONNECT", event.raw.bytes, req->content_len, self->base.custom_api.args);
+        break;
+    default:
+        self->base.custom_api.handler(self, req->uri, strlen(req->uri), "UNKNOWN", event.raw.bytes, req->content_len, self->base.custom_api.args);
+        break;
+    }
+
+    if (self->resp_size == 0)
+    {
+        xEventGroupClearBits(self->event_group, CIOT_HTTP_SERVER_RESP_READY_BIT);
+        xEventGroupWaitBits(
+            self->event_group,
+            CIOT_HTTP_SERVER_RESP_READY_BIT,
+            pdTRUE,
+            pdFALSE,
+            pdMS_TO_TICKS(CIOT_HTTP_SERVER_TIMEOUT_MS));
+    }
+
+    if (self->resp_size > 0)
+    {
+        CIOT_LOGI(TAG, "Resp OK");
+        httpd_resp_set_status(req, HTTPD_200);
+        httpd_resp_set_type(req, HTTPD_TYPE_OCTET);
+#ifdef CIOT_CONFIG_HTTP_SERVER_ALLOW_ORIGIN
+        httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", CIOT_CONFIG_HTTP_SERVER_ALLOW_ORIGIN);
+#endif
+        httpd_resp_send(req, (const char *)self->resp, self->resp_size);
+        self->resp_size = 0;
+    }
+    else
+    {
+        CIOT_LOGW(TAG, "Timeout waiting for response");
+        httpd_resp_send_500(req);
+    }
+
+    return CIOT_ERR_OK;
 }
 
 #endif //! CIOT_CONFIG_FEATURE_HTTP_SERVER == 1

--- a/src/esp32/ciot_wifi.c
+++ b/src/esp32/ciot_wifi.c
@@ -168,6 +168,16 @@ ciot_err_t ciot_wifi_scan(ciot_wifi_t self)
     return esp_wifi_scan_start(NULL, false);
 }
 
+ciot_err_t ciot_wifi_get_rssi(ciot_wifi_t self, int32_t *rssi)
+{
+    CIOT_ERR_NULL_CHECK(self);
+    CIOT_ERR_NULL_CHECK(rssi);
+    wifi_ap_record_t ap_info = { 0 };
+    esp_wifi_sta_get_ap_info(&ap_info);
+    *rssi = ap_info.rssi;
+    return CIOT_ERR_OK;
+}
+
 static esp_err_t esp_wifi_init_mode(ciot_wifi_type_t type)
 {
     wifi_mode_t mode;
@@ -395,10 +405,12 @@ static void ciot_wifi_sta_event_handler(void *handler_args, esp_event_base_t eve
         tcp->status->state = CIOT_TCP_STATE_CONNECTED;
         tcp->status->conn_count++;
         base->status.disconnect_reason = 0;
+        base->info.has_ap = true;
         base->info.ap.authmode = data->authmode;
         memcpy(base->info.ap.bssid, data->bssid, sizeof(data->bssid));
         memcpy(base->info.ap.ssid, data->ssid, sizeof(data->ssid));
         self->reconnecting = false;
+        ciot_wifi_get_rssi(self, &base->status.rssi);
         CIOT_ERR_PRINT(TAG, ciot_tcp_start(base->tcp));
         break;
     }

--- a/src/esp8266/ciot_wifi.c
+++ b/src/esp8266/ciot_wifi.c
@@ -168,6 +168,16 @@ ciot_err_t ciot_wifi_scan(ciot_wifi_t self)
     return esp_wifi_scan_start(NULL, false);
 }
 
+ciot_err_t ciot_wifi_get_rssi(ciot_wifi_t self, int32_t *rssi)
+{
+    CIOT_ERR_NULL_CHECK(self);
+    CIOT_ERR_NULL_CHECK(rssi);
+    wifi_ap_record_t ap_info = { 0 };
+    esp_wifi_sta_get_ap_info(&ap_info);
+    *rssi = ap_info.rssi;
+    return CIOT_ERR_OK;
+}
+
 static esp_err_t esp_wifi_init_mode(ciot_wifi_type_t type)
 {
     wifi_mode_t mode;

--- a/src/linux/ciot_wifi.c
+++ b/src/linux/ciot_wifi.c
@@ -95,6 +95,11 @@ ciot_err_t ciot_wifi_send_bytes(ciot_iface_t *iface, uint8_t *bytes, int size)
     return CIOT_ERR_NOT_SUPPORTED;
 }
 
+ciot_err_t ciot_wifi_get_rssi(ciot_wifi_t self, int32_t *rssi)
+{
+    return CIOT_ERR_NOT_SUPPORTED;
+}
+
 static ciot_err_t ciot_wifi_set_cfg(ciot_wifi_t self, ciot_wifi_cfg_t *cfg)
 {
     CIOT_LOGI(TAG, "Configuring");

--- a/src/mg/ciot_http_server.c
+++ b/src/mg/ciot_http_server.c
@@ -139,6 +139,10 @@ static void ciot_http_server_event_handler(struct mg_connection *c, int ev, void
             event.raw.size = hm->body.len;
             ciot_iface_send_event(&base->iface, &event);
         }
+        else if(self->base.custom_api.enabled && mg_match(hm->uri, mg_str(self->base.custom_api.uri), NULL))
+        {
+            self->base.custom_api.handler(self, hm->uri.buf, hm->uri.len, hm->method.buf, (uint8_t *)hm->body.buf, hm->body.len, self->base.custom_api.args);
+        }
         else if (mg_match(hm->uri, mg_str("/"), NULL) && check_method(hm, "GET") && base->homepage.size > 0)
         {
             mg_printf(self->conn_tx,

--- a/src/protos/ciot/proto/v2/msg.pb.h
+++ b/src/protos/ciot/proto/v2/msg.pb.h
@@ -30,6 +30,7 @@ typedef struct ciot_proxy {
     bool has_iface;
     ciot_iface_info_t iface; /* Proxy interface information. */
     ciot_proxy_state_t state; /* Proxy state. */
+    bool save; /* Use ciot to save msg data */
 } ciot_proxy_t;
 
 /* Represents an CioT message */
@@ -72,14 +73,15 @@ extern "C" {
 
 
 /* Initializer values for message structs */
-#define CIOT_PROXY_INIT_DEFAULT                  {false, CIOT_IFACE_INFO_INIT_DEFAULT, _CIOT_PROXY_STATE_MIN}
+#define CIOT_PROXY_INIT_DEFAULT                  {false, CIOT_IFACE_INFO_INIT_DEFAULT, _CIOT_PROXY_STATE_MIN, 0}
 #define CIOT_MSG_INIT_DEFAULT                    {0, false, CIOT_IFACE_INFO_INIT_DEFAULT, _CIOT_ERR_MIN, false, CIOT_MSG_DATA_INIT_DEFAULT, _CIOT_MSG_TYPE_MIN, false, CIOT_PROXY_INIT_DEFAULT}
-#define CIOT_PROXY_INIT_ZERO                     {false, CIOT_IFACE_INFO_INIT_ZERO, _CIOT_PROXY_STATE_MIN}
+#define CIOT_PROXY_INIT_ZERO                     {false, CIOT_IFACE_INFO_INIT_ZERO, _CIOT_PROXY_STATE_MIN, 0}
 #define CIOT_MSG_INIT_ZERO                       {0, false, CIOT_IFACE_INFO_INIT_ZERO, _CIOT_ERR_MIN, false, CIOT_MSG_DATA_INIT_ZERO, _CIOT_MSG_TYPE_MIN, false, CIOT_PROXY_INIT_ZERO}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define CIOT_PROXY_IFACE_TAG                     1
 #define CIOT_PROXY_STATE_TAG                     2
+#define CIOT_PROXY_SAVE_TAG                      3
 #define CIOT_MSG_ID_TAG                          1
 #define CIOT_MSG_IFACE_TAG                       2
 #define CIOT_MSG_ERROR_TAG                       3
@@ -90,7 +92,8 @@ extern "C" {
 /* Struct field encoding specification for nanopb */
 #define CIOT_PROXY_FIELDLIST(X, a) \
 X(a, STATIC,   OPTIONAL, MESSAGE,  iface,             1) \
-X(a, STATIC,   SINGULAR, UENUM,    state,             2)
+X(a, STATIC,   SINGULAR, UENUM,    state,             2) \
+X(a, STATIC,   SINGULAR, BOOL,     save,              3)
 #define CIOT_PROXY_CALLBACK NULL
 #define CIOT_PROXY_DEFAULT NULL
 #define ciot_proxy_t_iface_MSGTYPE ciot_iface_info_t
@@ -116,10 +119,10 @@ extern const pb_msgdesc_t ciot_msg_t_msg;
 #define CIOT_MSG_FIELDS &ciot_msg_t_msg
 
 /* Maximum encoded size of messages (where known) */
-#define CIOT_PROXY_SIZE                          12
+#define CIOT_PROXY_SIZE                          14
 #if defined(Ciot_MsgData_size)
 #define CIOT_CIOT_PROTO_V2_MSG_PB_H_MAX_SIZE     CIOT_MSG_SIZE
-#define CIOT_MSG_SIZE                            (40 + Ciot_MsgData_size)
+#define CIOT_MSG_SIZE                            (42 + Ciot_MsgData_size)
 #endif
 
 #ifdef __cplusplus

--- a/src/protos/ciot/proto/v2/wifi.pb.h
+++ b/src/protos/ciot/proto/v2/wifi.pb.h
@@ -55,6 +55,7 @@ typedef struct ciot_wifi_status {
     bool has_tcp;
     ciot_tcp_status_t tcp; /* Status of the TCP connection over Wi-Fi. */
     ciot_wifi_scan_state_t scan_state; /* Wi-Fi scan state */
+    int32_t rssi; /* Received Signal Strength Indicator (RSSI) */
 } ciot_wifi_status_t;
 
 typedef struct ciot_wifi_info {
@@ -139,7 +140,7 @@ extern "C" {
 #define CIOT_WIFI_AP_INFO_INIT_DEFAULT           {{0}, "", 0, 0}
 #define CIOT_WIFI_STOP_INIT_DEFAULT              {0}
 #define CIOT_WIFI_CFG_INIT_DEFAULT               {0, "", "", _CIOT_WIFI_TYPE_MIN, false, CIOT_TCP_CFG_INIT_DEFAULT}
-#define CIOT_WIFI_STATUS_INIT_DEFAULT            {0, false, CIOT_TCP_STATUS_INIT_DEFAULT, _CIOT_WIFI_SCAN_STATE_MIN}
+#define CIOT_WIFI_STATUS_INIT_DEFAULT            {0, false, CIOT_TCP_STATUS_INIT_DEFAULT, _CIOT_WIFI_SCAN_STATE_MIN, 0}
 #define CIOT_WIFI_INFO_INIT_DEFAULT              {false, CIOT_TCP_INFO_INIT_DEFAULT, false, CIOT_WIFI_AP_INFO_INIT_DEFAULT}
 #define CIOT_WIFI_REQ_SCAN_INIT_DEFAULT          {0}
 #define CIOT_WIFI_REQ_SCAN_RESULT_INIT_DEFAULT   {0}
@@ -149,7 +150,7 @@ extern "C" {
 #define CIOT_WIFI_AP_INFO_INIT_ZERO              {{0}, "", 0, 0}
 #define CIOT_WIFI_STOP_INIT_ZERO                 {0}
 #define CIOT_WIFI_CFG_INIT_ZERO                  {0, "", "", _CIOT_WIFI_TYPE_MIN, false, CIOT_TCP_CFG_INIT_ZERO}
-#define CIOT_WIFI_STATUS_INIT_ZERO               {0, false, CIOT_TCP_STATUS_INIT_ZERO, _CIOT_WIFI_SCAN_STATE_MIN}
+#define CIOT_WIFI_STATUS_INIT_ZERO               {0, false, CIOT_TCP_STATUS_INIT_ZERO, _CIOT_WIFI_SCAN_STATE_MIN, 0}
 #define CIOT_WIFI_INFO_INIT_ZERO                 {false, CIOT_TCP_INFO_INIT_ZERO, false, CIOT_WIFI_AP_INFO_INIT_ZERO}
 #define CIOT_WIFI_REQ_SCAN_INIT_ZERO             {0}
 #define CIOT_WIFI_REQ_SCAN_RESULT_INIT_ZERO      {0}
@@ -170,6 +171,7 @@ extern "C" {
 #define CIOT_WIFI_STATUS_DISCONNECT_REASON_TAG   1
 #define CIOT_WIFI_STATUS_TCP_TAG                 2
 #define CIOT_WIFI_STATUS_SCAN_STATE_TAG          3
+#define CIOT_WIFI_STATUS_RSSI_TAG                4
 #define CIOT_WIFI_INFO_TCP_TAG                   1
 #define CIOT_WIFI_INFO_AP_TAG                    2
 #define CIOT_WIFI_REQ_SCAN_RESULT_COUNT_TAG      1
@@ -211,7 +213,8 @@ X(a, STATIC,   OPTIONAL, MESSAGE,  tcp,               5)
 #define CIOT_WIFI_STATUS_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, UINT32,   disconnect_reason,   1) \
 X(a, STATIC,   OPTIONAL, MESSAGE,  tcp,               2) \
-X(a, STATIC,   SINGULAR, UENUM,    scan_state,        3)
+X(a, STATIC,   SINGULAR, UENUM,    scan_state,        3) \
+X(a, STATIC,   SINGULAR, INT32,    rssi,              4)
 #define CIOT_WIFI_STATUS_CALLBACK NULL
 #define CIOT_WIFI_STATUS_DEFAULT NULL
 #define ciot_wifi_status_t_tcp_MSGTYPE ciot_tcp_status_t
@@ -298,7 +301,7 @@ extern const pb_msgdesc_t ciot_wifi_data_t_msg;
 #define CIOT_WIFI_REQ_SCAN_RESULT_SIZE           6
 #define CIOT_WIFI_REQ_SCAN_SIZE                  0
 #define CIOT_WIFI_REQ_SIZE                       65
-#define CIOT_WIFI_STATUS_SIZE                    24
+#define CIOT_WIFI_STATUS_SIZE                    35
 #define CIOT_WIFI_STOP_SIZE                      0
 
 #ifdef __cplusplus

--- a/src/win/ciot_wifi.c
+++ b/src/win/ciot_wifi.c
@@ -79,6 +79,11 @@ ciot_err_t ciot_wifi_send_bytes(ciot_iface_t *iface, uint8_t *bytes, int size)
     return CIOT_ERR_NOT_SUPPORTED;
 }
 
+ciot_err_t ciot_wifi_get_rssi(ciot_wifi_t self, int32_t *rssi)
+{
+    return CIOT_ERR_NOT_SUPPORTED;
+}
+
 static ciot_err_t ciot_wifi_set_cfg(ciot_wifi_t self, ciot_wifi_cfg_t *cfg)
 {
     CIOT_LOGI(TAG, "Configuring");


### PR DESCRIPTION
This pull request introduces several enhancements and new features across the CIOT project, focusing on improved interface querying, expanded HTTP server customization, and enriched WiFi and Ethernet functionality. The changes add new API capabilities, enable custom HTTP endpoints, and provide better access to network information and device state.

**HTTP Server Customization:**

* Added support for registering custom API endpoints in the HTTP server, including a new handler type (`ciot_http_server_custom_api_handler_fn`), associated data structures, and the ability to enable/disable and handle custom routes at runtime. This allows users to define and process their own HTTP API endpoints through the CIOT HTTP server. [[1]](diffhunk://#diff-30be0adb0cad3dca9597199fc8e81a0da02c60e787a149fc2f378b9ea209fc1cR24-R25) [[2]](diffhunk://#diff-30be0adb0cad3dca9597199fc8e81a0da02c60e787a149fc2f378b9ea209fc1cR43-R57) [[3]](diffhunk://#diff-30be0adb0cad3dca9597199fc8e81a0da02c60e787a149fc2f378b9ea209fc1cR69) [[4]](diffhunk://#diff-c177ce0c72f538dbaee642d82ed4a16a68060a6fc05da2b6932c167920cea1f7L26-R31) [[5]](diffhunk://#diff-c177ce0c72f538dbaee642d82ed4a16a68060a6fc05da2b6932c167920cea1f7R49-R57) [[6]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692L36-R39) [[7]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692L59-R60) [[8]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692L96-R97) [[9]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692R108-R129) [[10]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692L121-R140) [[11]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692L169-R188) [[12]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692R293-R361)

**Network Interface Enhancements:**

* Added new APIs to retrieve the current IP address for both Ethernet (`ciot_eth_get_ip`) and WiFi (`ciot_wifi_get_ip`) interfaces, as well as to query the WiFi signal strength (`ciot_wifi_get_rssi`). These changes are implemented in both the interface headers and their respective source files. [[1]](diffhunk://#diff-fa4523ff179274410ba9796738b1f504e59afa76563a8ee1b0afabb9a6ce640eR37) [[2]](diffhunk://#diff-10c27a04ab9edf24529f28f38b31250b422c7699ec0d9c9a1a1c7fae81747629R140-R149) [[3]](diffhunk://#diff-ca06c9e501fbf825c6fd9ca3cd0cce0ce9db4ddb5c48c00c94d2c023ccb800d0R60-R61) [[4]](diffhunk://#diff-eef672241b635d4c1209cc3ad8db038d86150871db5b6aaf036ec69d255125d5R158-R166) [[5]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279R171-R180)
* The WiFi status retrieval now includes the latest RSSI value, and WiFi connection events update the RSSI and access point information. [[1]](diffhunk://#diff-eef672241b635d4c1209cc3ad8db038d86150871db5b6aaf036ec69d255125d5R135) [[2]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279R408-R413)

**DFU (Device Firmware Update) Improvements:**

* Added a "test mode" to the Nordic DFU implementation, including new struct members, API (`ciot_dfu_nrf_set_test_mode`), and logic to immediately complete ping responses and state transitions when in test mode. [[1]](diffhunk://#diff-74a286d93b9147cda2e796082ebafd561f5ffe864b6e7ef62c25a6043764bb84R102) [[2]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793L63-R63) [[3]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R95-R96) [[4]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R134-R140) [[5]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R463-R468)
* Improved logging for DFU events and start operations. [[1]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R95-R96) [[2]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793L588-R603)

**Core CIOT API Additions:**

* Introduced a new function (`ciot_iface_get_state`) to query the state of a specific interface by ID, with corresponding header and implementation updates. [[1]](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554R111) [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10R666-R672)

**Miscellaneous:**

* Minor improvements to event handling and logging, such as restoring event types after sending responses.

Let me know if you need clarification on any of these new features or how to use the new APIs!