### PR TITLE
Feat/v0.16.0.2

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -16,6 +16,16 @@
 * Added a "test mode" to the Nordic DFU implementation, including new struct members, API (`ciot_dfu_nrf_set_test_mode`), and logic to immediately complete ping responses and state transitions when in test mode. [[1]](diffhunk://#diff-74a286d93b9147cda2e796082ebafd561f5ffe864b6e7ef62c25a6043764bb84R102) [[2]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793L63-R63) [[3]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R95-R96) [[4]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R134-R140) [[5]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R463-R468)
 * Improved logging for DFU events and start operations. [[1]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R95-R96) [[2]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793L588-R603)
 
+**Storage auto-detection improvements:**
+
+* Refactored `ciot_storage_auto_new` in `src/esp32/ciot_storage_auto.c` to search for a data partition labeled `"storage"` instead of an app partition, return `NULL` if not found, and update the function signature to accept a `label` parameter. Also fixed the include from `.c` to `.h`.
+* Improved error handling and logging in `src/esp8266/ciot_storage_auto.c` by logging errors when no storage partition is found and indicating which storage type is being used.
+* Added new header file `include/ciot_storage_auto.h` for the storage auto-detection functionality, declaring the `ciot_storage_auto_new` function.
+
+**WiFi improvements:**
+
+* Updated `ciot_wifi_get_rssi` in `src/esp32/ciot_wifi.c` to only attempt to retrieve RSSI if the TCP state is connected, preventing invalid reads.
+
 **Core CIOT API Additions:**
 
 * Introduced a new function (`ciot_iface_get_state`) to query the state of a specific interface by ID, with corresponding header and implementation updates. [[1]](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554R111) [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10R666-R672)

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,16,0,1
+#define CIOT_VER 0,16,0,2
 #define CIOT_IFACE_CFG_FILENAME "cfg%d.dat"
 
 #if defined(CIOT_TARGET_WIN) || defined(CIOT_TARGET_LINUX)

--- a/include/ciot_storage_auto.h
+++ b/include/ciot_storage_auto.h
@@ -1,0 +1,19 @@
+/**
+ * @file ciot_storage_auto.h
+ * @author your name (you@domain.com)
+ * @brief 
+ * @version 0.1
+ * @date 2026-01-27
+ * 
+ * @copyright Copyright (c) 2026
+ * 
+ */
+
+#ifndef __CIOT_STORAGE_AUTO__H__
+#define __CIOT_STORAGE_AUTO__H__
+
+#include "ciot_storage.h"
+
+ciot_storage_t ciot_storage_auto_new(void);
+
+#endif  //!__CIOT_STORAGE_AUTO__H__

--- a/src/esp32/ciot_storage_auto.c
+++ b/src/esp32/ciot_storage_auto.c
@@ -22,13 +22,17 @@
 #include "ciot_storage.h"
 #include "ciot_storage_fs.h"
 #include "ciot_storage_fat.h"
-#include "ciot_storage_spiffs.c"
+#include "ciot_storage_spiffs.h"
 
 typedef struct ciot_storage_auto *ciot_storage_auto_t;
 
-ciot_storage_t ciot_storage_auto_new(void)
+ciot_storage_t ciot_storage_auto_new(const char *label)
 {
-    const esp_partition_t* partition = esp_partition_find_first(ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_ANY, FS_PARTITION_LABLE);
+    const esp_partition_t* partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, "storage");
+
+    if(partition == NULL) {
+        return NULL;
+    }
 
     switch (partition->subtype)
     {

--- a/src/esp32/ciot_wifi.c
+++ b/src/esp32/ciot_wifi.c
@@ -172,9 +172,12 @@ ciot_err_t ciot_wifi_get_rssi(ciot_wifi_t self, int32_t *rssi)
 {
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(rssi);
-    wifi_ap_record_t ap_info = { 0 };
-    esp_wifi_sta_get_ap_info(&ap_info);
-    *rssi = ap_info.rssi;
+    if(self->base.status.tcp.state == CIOT_TCP_STATE_CONNECTED)
+    {
+        wifi_ap_record_t ap_info = { 0 };
+        esp_wifi_sta_get_ap_info(&ap_info);
+        *rssi = ap_info.rssi;
+    }
     return CIOT_ERR_OK;
 }
 

--- a/src/esp8266/ciot_storage_auto.c
+++ b/src/esp8266/ciot_storage_auto.c
@@ -26,17 +26,28 @@
 
 typedef struct ciot_storage_auto *ciot_storage_auto_t;
 
+static const char *TAG = "ciot_storage_auto";
+
 ciot_storage_t ciot_storage_auto_new(void)
 {
     const esp_partition_t* partition = esp_partition_find_first(ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_ANY, FS_PARTITION_LABLE);
 
+    if(partition == NULL)
+    {
+        CIOT_LOGE(TAG, "No storage partition found");
+        return NULL;
+    }
+
     switch (partition->subtype)
     {
     case ESP_PARTITION_SUBTYPE_DATA_FAT:
+        CIOT_LOGI(TAG, "Using FAT storage");
         return ciot_storage_fat_new();
     case ESP_PARTITION_SUBTYPE_DATA_SPIFFS:
+        CIOT_LOGI(TAG, "Using SPIFFS storage");
         return ciot_storage_spiffs_new();
     default:
+        CIOT_LOGE(TAG, "No valid storage partition found");
         return NULL;
     }
 }


### PR DESCRIPTION
This pull request introduces improvements and fixes to the storage auto-detection logic for ESP32 and ESP8266 platforms, adds a new header for storage auto-detection, and includes a minor update to the WiFi RSSI retrieval logic. The changes enhance error handling, improve partition detection, and update versioning.

**Storage auto-detection improvements:**

* Refactored `ciot_storage_auto_new` in `src/esp32/ciot_storage_auto.c` to search for a data partition labeled `"storage"` instead of an app partition, return `NULL` if not found, and update the function signature to accept a `label` parameter. Also fixed the include from `.c` to `.h`.
* Improved error handling and logging in `src/esp8266/ciot_storage_auto.c` by logging errors when no storage partition is found and indicating which storage type is being used.
* Added new header file `include/ciot_storage_auto.h` for the storage auto-detection functionality, declaring the `ciot_storage_auto_new` function.

**WiFi improvements:**

* Updated `ciot_wifi_get_rssi` in `src/esp32/ciot_wifi.c` to only attempt to retrieve RSSI if the TCP state is connected, preventing invalid reads.

**Versioning:**

* Bumped `CIOT_VER` macro in `include/ciot.h` from `0,16,0,1` to `0,16,0,2`.