### PR TITLE
Feat/v0.16

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -33,3 +33,23 @@
 **Miscellaneous:**
 
 * Minor improvements to event handling and logging, such as restoring event types after sending responses.
+
+**NTP First Sync Time Tracking and API:**
+
+* Added `ciot_ntp_first_sync_time()` API to all platforms (ESP32, ESP8266, Linux, Windows) to provide the timestamp of the first successful NTP sync. This replaces previous per-platform mechanisms for tracking system initialization time. (`include/ciot_ntp.h`, `src/esp32/ciot_ntp.c`, `src/esp8266/ciot_ntp.c`, `src/linux/ciot_ntp.c`, `src/win/ciot_ntp.c`) [[1]](diffhunk://#diff-b7d92361932850e67d4b55a7249b2a1b60e327bdf86e6a79b19d98b6fd1008d5L47-R48) [[2]](diffhunk://#diff-b90864bd7b441575f4f4a33e3593ab52c575a94f98a545eef63c8a773520c506R49-R53) [[3]](diffhunk://#diff-f0e18b87ec4938a8558c8ad97950821b858f176e2970e152a000c75cc365a046R98-R102) [[4]](diffhunk://#diff-df1b9dfb52d12a962128af748d2d5da7ad0caad3239d5e56a45053218167102dR102-R106) [[5]](diffhunk://#diff-e0c9f32b0a2806032f895989391bb01b0e200ed3e637544fcdfee67ce3bdb011R51-R55) [[6]](diffhunk://#diff-8a0b3683cceb8a7edfbf8b6fff6eb6ea1d58b683cd520c5998b92e350b9b561eR51-R55)
+
+* Modified NTP synchronization callbacks to set `first_sync_time` only on the first successful sync, ensuring the timestamp is accurate and stable. (`src/esp32/ciot_ntp.c`, `src/esp8266/ciot_ntp.c`) [[1]](diffhunk://#diff-f0e18b87ec4938a8558c8ad97950821b858f176e2970e152a000c75cc365a046R112-R115) [[2]](diffhunk://#diff-df1b9dfb52d12a962128af748d2d5da7ad0caad3239d5e56a45053218167102dR117-R120)
+
+**System Lifetime Calculation Improvements:**
+
+* System lifetime is now calculated based on the time since the first NTP sync, instead of the previous `init_time` field, on all platforms. This ensures a more accurate representation of uptime relative to synchronized time. (`src/esp32/ciot_sys.c`, `src/esp8266/ciot_sys.c`, `src/linux/ciot_sys.c`, `src/win/ciot_sys.c`) [[1]](diffhunk://#diff-89e41b8a6f089a8c5a3cd4d31a6b4b8298d3e8fa721e6dca06bc4ad5f29c6b05L73-R73) [[2]](diffhunk://#diff-e0ea8830e0f110f5ab5be0bbfd4a810f6746a667332d85a5340ac96e210bcadaL73-R73) [[3]](diffhunk://#diff-d089c49e84691467dccbd06b177d3c6119299cee5f10ff1ecb42b366757e6943L65-R64) [[4]](diffhunk://#diff-34fc73335d58756935a3d9f6bff9b322edf0f956c5b105679c84be819182432bL65-R64)
+
+* Removed the `init_time` field from the `ciot_sys` struct, as it is no longer needed. (`src/esp32/ciot_sys.c`, `src/esp8266/ciot_sys.c`, `src/linux/ciot_sys.c`, `src/win/ciot_sys.c`) [[1]](diffhunk://#diff-89e41b8a6f089a8c5a3cd4d31a6b4b8298d3e8fa721e6dca06bc4ad5f29c6b05L29) [[2]](diffhunk://#diff-e0ea8830e0f110f5ab5be0bbfd4a810f6746a667332d85a5340ac96e210bcadaL29) [[3]](diffhunk://#diff-d089c49e84691467dccbd06b177d3c6119299cee5f10ff1ecb42b366757e6943R25-L31) [[4]](diffhunk://#diff-34fc73335d58756935a3d9f6bff9b322edf0f956c5b105679c84be819182432bR24-L31)
+
+**Error Handling Improvements:**
+
+* Improved null pointer checks in `ciot_mqtt_client_get_state()` and `ciot_iface_get_state()`, returning default states instead of relying solely on macros. (`src/common/ciot_mqtt_client_base.c`, `src/core/ciot.c`) [[1]](diffhunk://#diff-3c29355ff0857480c7a57573c88ad3ec552a012ff62443b7bcc7fd8537b3efb9L104-R107) [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L669-R672)
+
+**Header and Dependency Updates:**
+
+* Included necessary headers for `ciot_ntp.h` and platform-specific files to support the new API and ensure consistency. (`include/ciot_ntp.h`, `src/esp32/ciot_sys.c`, `src/esp8266/ciot_sys.c`, `src/linux/ciot_ntp.c`, `src/win/ciot_ntp.c`, `src/linux/ciot_sys.c`, `src/win/ciot_sys.c`) [[1]](diffhunk://#diff-b7d92361932850e67d4b55a7249b2a1b60e327bdf86e6a79b19d98b6fd1008d5R21) [[2]](diffhunk://#diff-89e41b8a6f089a8c5a3cd4d31a6b4b8298d3e8fa721e6dca06bc4ad5f29c6b05R21) [[3]](diffhunk://#diff-e0ea8830e0f110f5ab5be0bbfd4a810f6746a667332d85a5340ac96e210bcadaR13) [[4]](diffhunk://#diff-e0c9f32b0a2806032f895989391bb01b0e200ed3e637544fcdfee67ce3bdb011R18) [[5]](diffhunk://#diff-8a0b3683cceb8a7edfbf8b6fff6eb6ea1d58b683cd520c5998b92e350b9b561eR18) [[6]](diffhunk://#diff-d089c49e84691467dccbd06b177d3c6119299cee5f10ff1ecb42b366757e6943R25-L31) [[7]](diffhunk://#diff-34fc73335d58756935a3d9f6bff9b322edf0f956c5b105679c84be819182432bR24-L31)

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,16,0,2
+#define CIOT_VER 0,16,0,3
 #define CIOT_IFACE_CFG_FILENAME "cfg%d.dat"
 
 #if defined(CIOT_TARGET_WIN) || defined(CIOT_TARGET_LINUX)

--- a/include/ciot_ntp.h
+++ b/include/ciot_ntp.h
@@ -18,6 +18,7 @@ extern "C" {
 
 #include "ciot_types.h"
 #include "ciot_iface.h"
+#include <time.h>
 
 #ifndef CIOT_CONFIG_NTP_SERVER_URL_LEN
 #define CIOT_CONFIG_NTP_SERVER_URL_LEN 64
@@ -44,7 +45,7 @@ ciot_err_t ciot_ntp_process_req(ciot_ntp_t self, ciot_ntp_req_t *req);
 ciot_err_t ciot_ntp_get_cfg(ciot_ntp_t self, ciot_ntp_cfg_t *cfg);
 ciot_err_t ciot_ntp_set_cfg(ciot_ntp_t self, ciot_ntp_cfg_t *cfg);
 ciot_err_t ciot_ntp_get_status(ciot_ntp_t self, ciot_ntp_status_t *status);
-// ciot_err_t ciot_ntp_get_info(ciot_ntp_t self, ciot_ntp_info_t *info);
+time_t ciot_ntp_first_sync_time(void);
 
 #ifdef __cplusplus
 }

--- a/src/common/ciot_mqtt_client_base.c
+++ b/src/common/ciot_mqtt_client_base.c
@@ -101,7 +101,10 @@ ciot_err_t ciot_mqtt_client_set_subtopic(ciot_mqtt_client_t self, char *subtopic
 ciot_mqtt_client_state_t ciot_mqtt_client_get_state(ciot_mqtt_client_t self)
 {
     ciot_mqtt_client_base_t *base = (ciot_mqtt_client_base_t*)self;
-    CIOT_ERR_NULL_CHECK(self);
+    if(self == NULL)
+    {
+        return CIOT_MQTT_CLIENT_STATE_DISCONNECTED;
+    }
     return base->status.state;
 }
 

--- a/src/core/ciot.c
+++ b/src/core/ciot.c
@@ -666,7 +666,9 @@ static ciot_err_t ciot_bytes_received(ciot_t self, ciot_iface_t *sender, uint8_t
 
 ciot_iface_state_t ciot_iface_get_state(ciot_t self, uint16_t iface_id)
 {
-    CIOT_ERR_NULL_CHECK(self);
-    CIOT_ERR_ID_CHECK(iface_id, self->ifaces.count);
+    if(self == NULL || iface_id >= self->ifaces.count)
+    {
+        return CIOT_IFACE_STATE_STOPPED;
+    }
     return self->status.ifaces[iface_id].state;
 }

--- a/src/default/ciot_ntp.c
+++ b/src/default/ciot_ntp.c
@@ -46,4 +46,9 @@ ciot_err_t ciot_ntp_stop(ciot_ntp_t self)
     return CIOT_ERR_NOT_IMPLEMENTED;
 }
 
+time_t ciot_ntp_first_sync_time(void)
+{
+    return 0;
+}
+
 #endif // CIOT_CONFIG_FEATURE_NTP == 1

--- a/src/esp32/ciot_ntp.c
+++ b/src/esp32/ciot_ntp.c
@@ -20,6 +20,8 @@
 
 static const char *TAG = "ciot_ntp";
 
+static time_t first_sync_time = 0;
+
 struct ciot_ntp
 {
     ciot_ntp_base_t base;
@@ -93,6 +95,11 @@ ciot_err_t ciot_ntp_stop(ciot_ntp_t self)
     return CIOT_ERR_OK;
 }
 
+time_t ciot_ntp_first_sync_time(void)
+{
+    return first_sync_time;
+}
+
 static void ciot_ntp_sync_notification_cb(struct timeval *tv)
 {
     CIOT_LOGI(TAG, "Started");
@@ -102,6 +109,10 @@ static void ciot_ntp_sync_notification_cb(struct timeval *tv)
     base->status.sync = 1;
     base->status.sync_count++;
     base->status.last_sync = ciot_timer_now();
+    if(first_sync_time == 0)
+    {
+        first_sync_time = ciot_timer_now();
+    }   
     ciot_iface_send_event_type(&base->iface, CIOT_EVENT_TYPE_STARTED);
 }
 

--- a/src/esp32/ciot_sys.c
+++ b/src/esp32/ciot_sys.c
@@ -18,6 +18,7 @@
 #include "ciot_sys.h"
 #include "ciot_timer.h"
 #include "ciot_err.h"
+#include "ciot_ntp.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"
 
@@ -26,7 +27,6 @@
 struct ciot_sys
 {
     ciot_sys_base_t base;
-    uint64_t init_time;
     EventGroupHandle_t event_group;
 };
 
@@ -70,7 +70,7 @@ ciot_err_t ciot_sys_task(ciot_sys_t self)
 {
     ciot_sys_base_t *base = &self->base;
     base->status.free_memory = esp_get_free_heap_size();
-    base->status.lifetime = ciot_timer_now() - self->init_time;
+    base->status.lifetime = ciot_timer_now() - ciot_ntp_first_sync_time();
     xEventGroupWaitBits(self->event_group, CIOT_SYS_EVT_BIT_POOLING, pdTRUE, pdTRUE, pdMS_TO_TICKS(CIOT_SYS_DEFAULT_POOLING_INTERVAL_MS));
     return CIOT_ERR_OK;
 }

--- a/src/esp8266/ciot_ntp.c
+++ b/src/esp8266/ciot_ntp.c
@@ -26,6 +26,7 @@ struct ciot_ntp
 };
 
 void *notif_args;
+time_t first_sync_time = 0;
 
 static void ciot_ntp_sync_notification_cb(struct timeval *tv);
 
@@ -98,6 +99,11 @@ ciot_err_t ciot_ntp_stop(ciot_ntp_t self)
     return CIOT_ERR_OK;
 }
 
+time_t ciot_ntp_first_sync_time(void)
+{
+    return first_sync_time;
+}
+
 static void ciot_ntp_sync_notification_cb(struct timeval *tv)
 {
     CIOT_LOGI(TAG, "Started");
@@ -108,6 +114,10 @@ static void ciot_ntp_sync_notification_cb(struct timeval *tv)
     base->status.sync = 1;
     base->status.sync_count++;
     base->status.last_sync = ciot_timer_now();
+    if (first_sync_time == 0)
+    {
+        first_sync_time = ciot_timer_now();
+    }
     ciot_iface_send_event_type(&base->iface, CIOT_EVENT_TYPE_STARTED);
 }
 

--- a/src/esp8266/ciot_sys.c
+++ b/src/esp8266/ciot_sys.c
@@ -10,6 +10,7 @@
  */
 
  #include "ciot_config.h"
+ #include "ciot_ntp.h"
 
  #if CIOT_CONFIG_FEATURE_SYS == 1 && defined(CIOT_PLATFORM_ESP8266)
  
@@ -26,7 +27,6 @@
  struct ciot_sys
  {
      ciot_sys_base_t base;
-     uint64_t init_time;
      EventGroupHandle_t event_group;
  };
  
@@ -70,7 +70,7 @@
  {
      ciot_sys_base_t *base = &self->base;
      base->status.free_memory = esp_get_free_heap_size();
-     base->status.lifetime = ciot_timer_now() - self->init_time;
+     base->status.lifetime = ciot_timer_now() - ciot_ntp_first_sync_time();
      xEventGroupWaitBits(self->event_group, CIOT_SYS_EVT_BIT_POOLING, pdTRUE, pdTRUE, pdMS_TO_TICKS(CIOT_SYS_DEFAULT_POOLING_INTERVAL_MS));
      return CIOT_ERR_OK;
  }

--- a/src/linux/ciot_ntp.c
+++ b/src/linux/ciot_ntp.c
@@ -46,4 +46,9 @@ ciot_err_t ciot_ntp_stop(ciot_ntp_t self)
     return CIOT_ERR_NOT_SUPPORTED;
 }
 
+time_t ciot_ntp_first_sync_time(void)
+{
+    return 0;
+}
+
 #endif // CIOT_CONFIG_FEATURE_NTP == 1

--- a/src/linux/ciot_ntp.c
+++ b/src/linux/ciot_ntp.c
@@ -15,6 +15,7 @@
 
 #include <stdlib.h>
 #include "ciot_ntp.h"
+#include "ciot_timer.h"
 
 // static const char *TAG = "ciot_ntp";
 
@@ -24,6 +25,7 @@ struct ciot_ntp
 };
 
 void *notif_args;
+static time_t first_sync_time = 0;
 
 ciot_ntp_t ciot_ntp_new(void *handle)
 {
@@ -36,7 +38,7 @@ ciot_err_t ciot_ntp_start(ciot_ntp_t self, ciot_ntp_cfg_t *cfg)
 {
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(cfg);
-
+    first_sync_time = ciot_timer_now();
     return CIOT_ERR_NOT_SUPPORTED;
 }
 
@@ -48,7 +50,7 @@ ciot_err_t ciot_ntp_stop(ciot_ntp_t self)
 
 time_t ciot_ntp_first_sync_time(void)
 {
-    return 0;
+    return first_sync_time;
 }
 
 #endif // CIOT_CONFIG_FEATURE_NTP == 1

--- a/src/linux/ciot_sys.c
+++ b/src/linux/ciot_sys.c
@@ -22,6 +22,7 @@
 #include "ciot_err.h"
 #include "ciot_timer.h"
 #include "mongoose.h"
+#include "ciot_ntp.h"
 
 static const char *TAG = "ciot_sys";
 

--- a/src/linux/ciot_sys.c
+++ b/src/linux/ciot_sys.c
@@ -28,7 +28,6 @@ static const char *TAG = "ciot_sys";
 struct ciot_sys
 {
     ciot_sys_base_t base;
-    time_t init_time;
 };
 
 static uint32_t ciot_sys_get_free_ram(void);
@@ -47,7 +46,6 @@ ciot_sys_t ciot_sys_new(void *handle)
 ciot_err_t ciot_sys_start(ciot_sys_t self, ciot_sys_cfg_t *cfg)
 {
     CIOT_ERR_NULL_CHECK(self);
-    self->init_time = ciot_timer_now();
     return ciot_iface_send_event_type(&self->base.iface, CIOT_EVENT_TYPE_STARTED);
 }
 
@@ -62,7 +60,7 @@ ciot_err_t ciot_sys_task(ciot_sys_t self)
 {
     CIOT_ERR_NULL_CHECK(self);
     sys->base.status.free_memory = ciot_sys_get_free_ram();
-    sys->base.status.lifetime = ciot_timer_now() - sys->init_time;
+    sys->base.status.lifetime = ciot_timer_now();
     return CIOT_ERR_OK;
 }
 

--- a/src/win/ciot_ntp.c
+++ b/src/win/ciot_ntp.c
@@ -15,6 +15,7 @@
 
 #include <stdlib.h>
 #include "ciot_ntp.h"
+#include "ciot_timer.h"
 
 // static const char *TAG = "ciot_ntp";
 
@@ -24,6 +25,7 @@ struct ciot_ntp
 };
 
 void *notif_args;
+static time_t first_sync_time = 0;
 
 ciot_ntp_t ciot_ntp_new(void *handle)
 {
@@ -36,7 +38,7 @@ ciot_err_t ciot_ntp_start(ciot_ntp_t self, ciot_ntp_cfg_t *cfg)
 {
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(cfg);
-
+    first_sync_time = ciot_timer_now();
     return CIOT_ERR_NOT_SUPPORTED;
 }
 
@@ -44,6 +46,11 @@ ciot_err_t ciot_ntp_stop(ciot_ntp_t self)
 {
     CIOT_ERR_NULL_CHECK(self);
     return CIOT_ERR_NOT_SUPPORTED;
+}
+
+time_t ciot_ntp_first_sync_time(void)
+{
+    return first_sync_time;
 }
 
 #endif // CIOT_CONFIG_FEATURE_NTP == 1

--- a/src/win/ciot_sys.c
+++ b/src/win/ciot_sys.c
@@ -28,7 +28,6 @@ static const char *TAG = "ciot_sys";
 struct ciot_sys
 {
     ciot_sys_base_t base;
-    time_t init_time;
 };
 
 static uint32_t ciot_sys_get_free_ram(void);
@@ -47,7 +46,6 @@ ciot_sys_t ciot_sys_new(void *handle)
 ciot_err_t ciot_sys_start(ciot_sys_t self, ciot_sys_cfg_t *cfg)
 {
     CIOT_ERR_NULL_CHECK(self);
-    self->init_time = ciot_timer_now();
     return ciot_iface_send_event_type(&self->base.iface, CIOT_EVENT_TYPE_STARTED);
 }
 
@@ -62,7 +60,7 @@ ciot_err_t ciot_sys_task(ciot_sys_t self)
 {
     CIOT_ERR_NULL_CHECK(self);
     sys->base.status.free_memory = ciot_sys_get_free_ram();
-    sys->base.status.lifetime = ciot_timer_now() - sys->init_time;
+    sys->base.status.lifetime = ciot_timer_now();
     return CIOT_ERR_OK;
 }
 

--- a/src/win/ciot_sys.c
+++ b/src/win/ciot_sys.c
@@ -21,6 +21,7 @@
 #include "ciot_sys.h"
 #include "ciot_err.h"
 #include "ciot_timer.h"
+#include "ciot_ntp.h"
 #include "mongoose.h"
 
 static const char *TAG = "ciot_sys";
@@ -60,7 +61,7 @@ ciot_err_t ciot_sys_task(ciot_sys_t self)
 {
     CIOT_ERR_NULL_CHECK(self);
     sys->base.status.free_memory = ciot_sys_get_free_ram();
-    sys->base.status.lifetime = ciot_timer_now();
+    sys->base.status.lifetime = ciot_timer_now() - ciot_ntp_first_sync_time();
     return CIOT_ERR_OK;
 }
 


### PR DESCRIPTION
This pull request introduces a unified way to track the first successful NTP synchronization time across all supported platforms. The `ciot_ntp_first_sync_time()` function is added and used to improve the accuracy of system lifetime calculations, replacing previous platform-specific approaches. The update also includes minor improvements to error handling in MQTT and interface state getters.

Key changes:

**NTP First Sync Time Tracking and API:**

* Added `ciot_ntp_first_sync_time()` API to all platforms (ESP32, ESP8266, Linux, Windows) to provide the timestamp of the first successful NTP sync. This replaces previous per-platform mechanisms for tracking system initialization time. (`include/ciot_ntp.h`, `src/esp32/ciot_ntp.c`, `src/esp8266/ciot_ntp.c`, `src/linux/ciot_ntp.c`, `src/win/ciot_ntp.c`) [[1]](diffhunk://#diff-b7d92361932850e67d4b55a7249b2a1b60e327bdf86e6a79b19d98b6fd1008d5L47-R48) [[2]](diffhunk://#diff-b90864bd7b441575f4f4a33e3593ab52c575a94f98a545eef63c8a773520c506R49-R53) [[3]](diffhunk://#diff-f0e18b87ec4938a8558c8ad97950821b858f176e2970e152a000c75cc365a046R98-R102) [[4]](diffhunk://#diff-df1b9dfb52d12a962128af748d2d5da7ad0caad3239d5e56a45053218167102dR102-R106) [[5]](diffhunk://#diff-e0c9f32b0a2806032f895989391bb01b0e200ed3e637544fcdfee67ce3bdb011R51-R55) [[6]](diffhunk://#diff-8a0b3683cceb8a7edfbf8b6fff6eb6ea1d58b683cd520c5998b92e350b9b561eR51-R55)

* Modified NTP synchronization callbacks to set `first_sync_time` only on the first successful sync, ensuring the timestamp is accurate and stable. (`src/esp32/ciot_ntp.c`, `src/esp8266/ciot_ntp.c`) [[1]](diffhunk://#diff-f0e18b87ec4938a8558c8ad97950821b858f176e2970e152a000c75cc365a046R112-R115) [[2]](diffhunk://#diff-df1b9dfb52d12a962128af748d2d5da7ad0caad3239d5e56a45053218167102dR117-R120)

**System Lifetime Calculation Improvements:**

* System lifetime is now calculated based on the time since the first NTP sync, instead of the previous `init_time` field, on all platforms. This ensures a more accurate representation of uptime relative to synchronized time. (`src/esp32/ciot_sys.c`, `src/esp8266/ciot_sys.c`, `src/linux/ciot_sys.c`, `src/win/ciot_sys.c`) [[1]](diffhunk://#diff-89e41b8a6f089a8c5a3cd4d31a6b4b8298d3e8fa721e6dca06bc4ad5f29c6b05L73-R73) [[2]](diffhunk://#diff-e0ea8830e0f110f5ab5be0bbfd4a810f6746a667332d85a5340ac96e210bcadaL73-R73) [[3]](diffhunk://#diff-d089c49e84691467dccbd06b177d3c6119299cee5f10ff1ecb42b366757e6943L65-R64) [[4]](diffhunk://#diff-34fc73335d58756935a3d9f6bff9b322edf0f956c5b105679c84be819182432bL65-R64)

* Removed the `init_time` field from the `ciot_sys` struct, as it is no longer needed. (`src/esp32/ciot_sys.c`, `src/esp8266/ciot_sys.c`, `src/linux/ciot_sys.c`, `src/win/ciot_sys.c`) [[1]](diffhunk://#diff-89e41b8a6f089a8c5a3cd4d31a6b4b8298d3e8fa721e6dca06bc4ad5f29c6b05L29) [[2]](diffhunk://#diff-e0ea8830e0f110f5ab5be0bbfd4a810f6746a667332d85a5340ac96e210bcadaL29) [[3]](diffhunk://#diff-d089c49e84691467dccbd06b177d3c6119299cee5f10ff1ecb42b366757e6943R25-L31) [[4]](diffhunk://#diff-34fc73335d58756935a3d9f6bff9b322edf0f956c5b105679c84be819182432bR24-L31)

**Error Handling Improvements:**

* Improved null pointer checks in `ciot_mqtt_client_get_state()` and `ciot_iface_get_state()`, returning default states instead of relying solely on macros. (`src/common/ciot_mqtt_client_base.c`, `src/core/ciot.c`) [[1]](diffhunk://#diff-3c29355ff0857480c7a57573c88ad3ec552a012ff62443b7bcc7fd8537b3efb9L104-R107) [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L669-R672)

**Header and Dependency Updates:**

* Included necessary headers for `ciot_ntp.h` and platform-specific files to support the new API and ensure consistency. (`include/ciot_ntp.h`, `src/esp32/ciot_sys.c`, `src/esp8266/ciot_sys.c`, `src/linux/ciot_ntp.c`, `src/win/ciot_ntp.c`, `src/linux/ciot_sys.c`, `src/win/ciot_sys.c`) [[1]](diffhunk://#diff-b7d92361932850e67d4b55a7249b2a1b60e327bdf86e6a79b19d98b6fd1008d5R21) [[2]](diffhunk://#diff-89e41b8a6f089a8c5a3cd4d31a6b4b8298d3e8fa721e6dca06bc4ad5f29c6b05R21) [[3]](diffhunk://#diff-e0ea8830e0f110f5ab5be0bbfd4a810f6746a667332d85a5340ac96e210bcadaR13) [[4]](diffhunk://#diff-e0c9f32b0a2806032f895989391bb01b0e200ed3e637544fcdfee67ce3bdb011R18) [[5]](diffhunk://#diff-8a0b3683cceb8a7edfbf8b6fff6eb6ea1d58b683cd520c5998b92e350b9b561eR18) [[6]](diffhunk://#diff-d089c49e84691467dccbd06b177d3c6119299cee5f10ff1ecb42b366757e6943R25-L31) [[7]](diffhunk://#diff-34fc73335d58756935a3d9f6bff9b322edf0f956c5b105679c84be819182432bR24-L31)