### PR TITLE
Develop

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,10 +2,24 @@
 
 ### Changes
 
-**Proxy request handling improvements:**
+**HTTP Server Customization:**
 
-* Added a new condition in `ciot_busy_task` (in `ciot.c`) to save interface configuration data when a proxy request with `save` set to true is received. This involves generating a filename, saving the data to storage, updating the proxy state, sending a response, and logging the operation.
+* Added support for registering custom API endpoints in the HTTP server, including a new handler type (`ciot_http_server_custom_api_handler_fn`), associated data structures, and the ability to enable/disable and handle custom routes at runtime. This allows users to define and process their own HTTP API endpoints through the CIOT HTTP server. [[1]](diffhunk://#diff-30be0adb0cad3dca9597199fc8e81a0da02c60e787a149fc2f378b9ea209fc1cR24-R25) [[2]](diffhunk://#diff-30be0adb0cad3dca9597199fc8e81a0da02c60e787a149fc2f378b9ea209fc1cR43-R57) [[3]](diffhunk://#diff-30be0adb0cad3dca9597199fc8e81a0da02c60e787a149fc2f378b9ea209fc1cR69) [[4]](diffhunk://#diff-c177ce0c72f538dbaee642d82ed4a16a68060a6fc05da2b6932c167920cea1f7L26-R31) [[5]](diffhunk://#diff-c177ce0c72f538dbaee642d82ed4a16a68060a6fc05da2b6932c167920cea1f7R49-R57) [[6]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692L36-R39) [[7]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692L59-R60) [[8]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692L96-R97) [[9]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692R108-R129) [[10]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692L121-R140) [[11]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692L169-R188) [[12]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692R293-R361)
 
-**Minor formatting fix:**
+**Network Interface Enhancements:**
 
-* Moved the `#endif // CONFIG_ESP_HTTPS_OTA_DECRYPT_CB` directive to after the function declaration in `ciot_ota.c` to correctly scope conditional compilation.
+* Added new APIs to retrieve the current IP address for both Ethernet (`ciot_eth_get_ip`) and WiFi (`ciot_wifi_get_ip`) interfaces, as well as to query the WiFi signal strength (`ciot_wifi_get_rssi`). These changes are implemented in both the interface headers and their respective source files. [[1]](diffhunk://#diff-fa4523ff179274410ba9796738b1f504e59afa76563a8ee1b0afabb9a6ce640eR37) [[2]](diffhunk://#diff-10c27a04ab9edf24529f28f38b31250b422c7699ec0d9c9a1a1c7fae81747629R140-R149) [[3]](diffhunk://#diff-ca06c9e501fbf825c6fd9ca3cd0cce0ce9db4ddb5c48c00c94d2c023ccb800d0R60-R61) [[4]](diffhunk://#diff-eef672241b635d4c1209cc3ad8db038d86150871db5b6aaf036ec69d255125d5R158-R166) [[5]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279R171-R180)
+* The WiFi status retrieval now includes the latest RSSI value, and WiFi connection events update the RSSI and access point information. [[1]](diffhunk://#diff-eef672241b635d4c1209cc3ad8db038d86150871db5b6aaf036ec69d255125d5R135) [[2]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279R408-R413)
+
+**DFU (Device Firmware Update) Improvements:**
+
+* Added a "test mode" to the Nordic DFU implementation, including new struct members, API (`ciot_dfu_nrf_set_test_mode`), and logic to immediately complete ping responses and state transitions when in test mode. [[1]](diffhunk://#diff-74a286d93b9147cda2e796082ebafd561f5ffe864b6e7ef62c25a6043764bb84R102) [[2]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793L63-R63) [[3]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R95-R96) [[4]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R134-R140) [[5]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R463-R468)
+* Improved logging for DFU events and start operations. [[1]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R95-R96) [[2]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793L588-R603)
+
+**Core CIOT API Additions:**
+
+* Introduced a new function (`ciot_iface_get_state`) to query the state of a specific interface by ID, with corresponding header and implementation updates. [[1]](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554R111) [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10R666-R672)
+
+**Miscellaneous:**
+
+* Minor improvements to event handling and logging, such as restoring event types after sending responses.

--- a/changes.md
+++ b/changes.md
@@ -33,3 +33,23 @@
 **Miscellaneous:**
 
 * Minor improvements to event handling and logging, such as restoring event types after sending responses.
+
+**NTP First Sync Time Tracking and API:**
+
+* Added `ciot_ntp_first_sync_time()` API to all platforms (ESP32, ESP8266, Linux, Windows) to provide the timestamp of the first successful NTP sync. This replaces previous per-platform mechanisms for tracking system initialization time. (`include/ciot_ntp.h`, `src/esp32/ciot_ntp.c`, `src/esp8266/ciot_ntp.c`, `src/linux/ciot_ntp.c`, `src/win/ciot_ntp.c`) [[1]](diffhunk://#diff-b7d92361932850e67d4b55a7249b2a1b60e327bdf86e6a79b19d98b6fd1008d5L47-R48) [[2]](diffhunk://#diff-b90864bd7b441575f4f4a33e3593ab52c575a94f98a545eef63c8a773520c506R49-R53) [[3]](diffhunk://#diff-f0e18b87ec4938a8558c8ad97950821b858f176e2970e152a000c75cc365a046R98-R102) [[4]](diffhunk://#diff-df1b9dfb52d12a962128af748d2d5da7ad0caad3239d5e56a45053218167102dR102-R106) [[5]](diffhunk://#diff-e0c9f32b0a2806032f895989391bb01b0e200ed3e637544fcdfee67ce3bdb011R51-R55) [[6]](diffhunk://#diff-8a0b3683cceb8a7edfbf8b6fff6eb6ea1d58b683cd520c5998b92e350b9b561eR51-R55)
+
+* Modified NTP synchronization callbacks to set `first_sync_time` only on the first successful sync, ensuring the timestamp is accurate and stable. (`src/esp32/ciot_ntp.c`, `src/esp8266/ciot_ntp.c`) [[1]](diffhunk://#diff-f0e18b87ec4938a8558c8ad97950821b858f176e2970e152a000c75cc365a046R112-R115) [[2]](diffhunk://#diff-df1b9dfb52d12a962128af748d2d5da7ad0caad3239d5e56a45053218167102dR117-R120)
+
+**System Lifetime Calculation Improvements:**
+
+* System lifetime is now calculated based on the time since the first NTP sync, instead of the previous `init_time` field, on all platforms. This ensures a more accurate representation of uptime relative to synchronized time. (`src/esp32/ciot_sys.c`, `src/esp8266/ciot_sys.c`, `src/linux/ciot_sys.c`, `src/win/ciot_sys.c`) [[1]](diffhunk://#diff-89e41b8a6f089a8c5a3cd4d31a6b4b8298d3e8fa721e6dca06bc4ad5f29c6b05L73-R73) [[2]](diffhunk://#diff-e0ea8830e0f110f5ab5be0bbfd4a810f6746a667332d85a5340ac96e210bcadaL73-R73) [[3]](diffhunk://#diff-d089c49e84691467dccbd06b177d3c6119299cee5f10ff1ecb42b366757e6943L65-R64) [[4]](diffhunk://#diff-34fc73335d58756935a3d9f6bff9b322edf0f956c5b105679c84be819182432bL65-R64)
+
+* Removed the `init_time` field from the `ciot_sys` struct, as it is no longer needed. (`src/esp32/ciot_sys.c`, `src/esp8266/ciot_sys.c`, `src/linux/ciot_sys.c`, `src/win/ciot_sys.c`) [[1]](diffhunk://#diff-89e41b8a6f089a8c5a3cd4d31a6b4b8298d3e8fa721e6dca06bc4ad5f29c6b05L29) [[2]](diffhunk://#diff-e0ea8830e0f110f5ab5be0bbfd4a810f6746a667332d85a5340ac96e210bcadaL29) [[3]](diffhunk://#diff-d089c49e84691467dccbd06b177d3c6119299cee5f10ff1ecb42b366757e6943R25-L31) [[4]](diffhunk://#diff-34fc73335d58756935a3d9f6bff9b322edf0f956c5b105679c84be819182432bR24-L31)
+
+**Error Handling Improvements:**
+
+* Improved null pointer checks in `ciot_mqtt_client_get_state()` and `ciot_iface_get_state()`, returning default states instead of relying solely on macros. (`src/common/ciot_mqtt_client_base.c`, `src/core/ciot.c`) [[1]](diffhunk://#diff-3c29355ff0857480c7a57573c88ad3ec552a012ff62443b7bcc7fd8537b3efb9L104-R107) [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L669-R672)
+
+**Header and Dependency Updates:**
+
+* Included necessary headers for `ciot_ntp.h` and platform-specific files to support the new API and ensure consistency. (`include/ciot_ntp.h`, `src/esp32/ciot_sys.c`, `src/esp8266/ciot_sys.c`, `src/linux/ciot_ntp.c`, `src/win/ciot_ntp.c`, `src/linux/ciot_sys.c`, `src/win/ciot_sys.c`) [[1]](diffhunk://#diff-b7d92361932850e67d4b55a7249b2a1b60e327bdf86e6a79b19d98b6fd1008d5R21) [[2]](diffhunk://#diff-89e41b8a6f089a8c5a3cd4d31a6b4b8298d3e8fa721e6dca06bc4ad5f29c6b05R21) [[3]](diffhunk://#diff-e0ea8830e0f110f5ab5be0bbfd4a810f6746a667332d85a5340ac96e210bcadaR13) [[4]](diffhunk://#diff-e0c9f32b0a2806032f895989391bb01b0e200ed3e637544fcdfee67ce3bdb011R18) [[5]](diffhunk://#diff-8a0b3683cceb8a7edfbf8b6fff6eb6ea1d58b683cd520c5998b92e350b9b561eR18) [[6]](diffhunk://#diff-d089c49e84691467dccbd06b177d3c6119299cee5f10ff1ecb42b366757e6943R25-L31) [[7]](diffhunk://#diff-34fc73335d58756935a3d9f6bff9b322edf0f956c5b105679c84be819182432bR24-L31)

--- a/changes.md
+++ b/changes.md
@@ -16,6 +16,16 @@
 * Added a "test mode" to the Nordic DFU implementation, including new struct members, API (`ciot_dfu_nrf_set_test_mode`), and logic to immediately complete ping responses and state transitions when in test mode. [[1]](diffhunk://#diff-74a286d93b9147cda2e796082ebafd561f5ffe864b6e7ef62c25a6043764bb84R102) [[2]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793L63-R63) [[3]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R95-R96) [[4]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R134-R140) [[5]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R463-R468)
 * Improved logging for DFU events and start operations. [[1]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R95-R96) [[2]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793L588-R603)
 
+**Storage auto-detection improvements:**
+
+* Refactored `ciot_storage_auto_new` in `src/esp32/ciot_storage_auto.c` to search for a data partition labeled `"storage"` instead of an app partition, return `NULL` if not found, and update the function signature to accept a `label` parameter. Also fixed the include from `.c` to `.h`.
+* Improved error handling and logging in `src/esp8266/ciot_storage_auto.c` by logging errors when no storage partition is found and indicating which storage type is being used.
+* Added new header file `include/ciot_storage_auto.h` for the storage auto-detection functionality, declaring the `ciot_storage_auto_new` function.
+
+**WiFi improvements:**
+
+* Updated `ciot_wifi_get_rssi` in `src/esp32/ciot_wifi.c` to only attempt to retrieve RSSI if the TCP state is connected, preventing invalid reads.
+
 **Core CIOT API Additions:**
 
 * Introduced a new function (`ciot_iface_get_state`) to query the state of a specific interface by ID, with corresponding header and implementation updates. [[1]](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554R111) [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10R666-R672)

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,16,0,1
+#define CIOT_VER 0,16,0,2
 #define CIOT_IFACE_CFG_FILENAME "cfg%d.dat"
 
 #if defined(CIOT_TARGET_WIN) || defined(CIOT_TARGET_LINUX)

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,16,0,0
+#define CIOT_VER 0,16,0,1
 #define CIOT_IFACE_CFG_FILENAME "cfg%d.dat"
 
 #if defined(CIOT_TARGET_WIN) || defined(CIOT_TARGET_LINUX)

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,15,0,0
+#define CIOT_VER 0,16,0,0
 #define CIOT_IFACE_CFG_FILENAME "cfg%d.dat"
 
 #if defined(CIOT_TARGET_WIN) || defined(CIOT_TARGET_LINUX)

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,16,0,2
+#define CIOT_VER 0,16,0,3
 #define CIOT_IFACE_CFG_FILENAME "cfg%d.dat"
 
 #if defined(CIOT_TARGET_WIN) || defined(CIOT_TARGET_LINUX)

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -108,5 +108,6 @@ ciot_err_t ciot_get_ifaces_info(ciot_t self, ciot_info_t *info);
 ciot_err_t ciot_delete_all(ciot_t self);
 bool ciot_cfg_exists(ciot_t self, uint8_t iface_id);
 const char *ciot_event_to_str(ciot_event_t *event);
+ciot_iface_state_t ciot_iface_get_state(ciot_t self, uint16_t iface_id);
 
 #endif  //!__CIOT__H__

--- a/include/ciot_dfu_nrf.h
+++ b/include/ciot_dfu_nrf.h
@@ -99,6 +99,7 @@ typedef struct ciot_dfu_nrf *ciot_dfu_nrf_t;
 ciot_dfu_nrf_t ciot_dfu_nrf_new(ciot_dfu_nrf_cfg_t *cfg);
 ciot_err_t ciot_dfu_nrf_start(ciot_dfu_nrf_t self, ciot_dfu_cfg_t *cfg);
 ciot_err_t ciot_dfu_nrf_stop(ciot_dfu_nrf_t self);
+ciot_err_t ciot_dfu_nrf_set_test_mode(ciot_dfu_nrf_t self, bool enable);
 ciot_err_t ciot_dfu_nrf_init(ciot_dfu_nrf_t self);
 ciot_err_t ciot_dfu_nrf_process_req(ciot_dfu_nrf_t self, ciot_dfu_req_t *req);
 ciot_err_t ciot_dfu_nrf_get_cfg(ciot_dfu_nrf_t self, ciot_dfu_cfg_t *cfg);

--- a/include/ciot_eth.h
+++ b/include/ciot_eth.h
@@ -34,5 +34,6 @@ ciot_err_t ciot_eth_get_cfg(ciot_eth_t self, ciot_tcp_cfg_t *cfg);
 ciot_err_t ciot_eth_get_status(ciot_eth_t self, ciot_tcp_status_t *status);
 ciot_err_t ciot_eth_get_info(ciot_eth_t self, ciot_tcp_info_t *info);
 ciot_err_t ciot_eth_get_mac(ciot_eth_t self, uint8_t mac[6]);
+ciot_err_t ciot_eth_get_ip(ciot_eth_t self, uint8_t ip[4]);
 
 #endif  //!__CIOT_ETH__H__

--- a/include/ciot_http_server.h
+++ b/include/ciot_http_server.h
@@ -21,6 +21,8 @@ extern "C" {
 
 typedef struct ciot_http_server *ciot_http_server_t;
 
+typedef ciot_err_t (ciot_http_server_custom_api_handler_fn)(ciot_http_server_t self, const char *uri, size_t uri_len, char *method, uint8_t *data, size_t size, void *args);
+
 #ifndef CIOT_CONFIG_URL_SIZE
 #define CIOT_CONFIG_URL_SIZE 48
 #endif
@@ -38,12 +40,21 @@ typedef struct ciot_http_server_homepage_cfg
     size_t size;
 } ciot_http_server_homepage_cfg_t;
 
+typedef struct ciot_http_server_custom_api
+{
+    bool enabled;
+    const char *uri;
+    ciot_http_server_custom_api_handler_fn *handler;
+    void *args;
+} ciot_http_server_custom_api_t;
+
 typedef struct ciot_http_server_base
 {
     ciot_iface_t iface;
     ciot_http_server_cfg_t cfg;
     ciot_http_server_status_t status;
     ciot_http_server_homepage_cfg_t homepage;
+    ciot_http_server_custom_api_t custom_api;
 } ciot_http_server_base_t;
 
 ciot_http_server_t ciot_http_server_new(void *handle);
@@ -55,6 +66,7 @@ ciot_err_t ciot_http_server_get_cfg(ciot_http_server_t self, ciot_http_server_cf
 ciot_err_t ciot_http_server_get_status(ciot_http_server_t self, ciot_http_server_status_t *status);
 ciot_err_t ciot_http_server_send_bytes(ciot_http_server_t self, uint8_t *data, int size);
 ciot_err_t ciot_http_server_set_homepage(ciot_http_server_t self, ciot_http_server_homepage_cfg_t *homepage);
+ciot_err_t ciot_http_server_set_custom_api(ciot_http_server_t self, ciot_http_server_custom_api_t *custom_api);
 
 #ifdef __cplusplus
 }

--- a/include/ciot_ntp.h
+++ b/include/ciot_ntp.h
@@ -18,6 +18,7 @@ extern "C" {
 
 #include "ciot_types.h"
 #include "ciot_iface.h"
+#include <time.h>
 
 #ifndef CIOT_CONFIG_NTP_SERVER_URL_LEN
 #define CIOT_CONFIG_NTP_SERVER_URL_LEN 64
@@ -44,7 +45,7 @@ ciot_err_t ciot_ntp_process_req(ciot_ntp_t self, ciot_ntp_req_t *req);
 ciot_err_t ciot_ntp_get_cfg(ciot_ntp_t self, ciot_ntp_cfg_t *cfg);
 ciot_err_t ciot_ntp_set_cfg(ciot_ntp_t self, ciot_ntp_cfg_t *cfg);
 ciot_err_t ciot_ntp_get_status(ciot_ntp_t self, ciot_ntp_status_t *status);
-// ciot_err_t ciot_ntp_get_info(ciot_ntp_t self, ciot_ntp_info_t *info);
+time_t ciot_ntp_first_sync_time(void);
 
 #ifdef __cplusplus
 }

--- a/include/ciot_storage_auto.h
+++ b/include/ciot_storage_auto.h
@@ -1,0 +1,19 @@
+/**
+ * @file ciot_storage_auto.h
+ * @author your name (you@domain.com)
+ * @brief 
+ * @version 0.1
+ * @date 2026-01-27
+ * 
+ * @copyright Copyright (c) 2026
+ * 
+ */
+
+#ifndef __CIOT_STORAGE_AUTO__H__
+#define __CIOT_STORAGE_AUTO__H__
+
+#include "ciot_storage.h"
+
+ciot_storage_t ciot_storage_auto_new(void);
+
+#endif  //!__CIOT_STORAGE_AUTO__H__

--- a/include/ciot_sys.h
+++ b/include/ciot_sys.h
@@ -20,6 +20,7 @@ extern "C" {
 #include "ciot_iface.h"
 
 #define CIOT_SYS_EVT_BIT_POOLING 0x00000001
+#define CIOT_SYS_DEFAULT_POOLING_INTERVAL_MS 100
 
 typedef struct ciot_sys *ciot_sys_t;
 

--- a/include/ciot_wifi.h
+++ b/include/ciot_wifi.h
@@ -57,6 +57,8 @@ ciot_err_t ciot_wifi_toggle(ciot_wifi_t self);
 ciot_err_t ciot_wifi_scan(ciot_wifi_t self);
 ciot_err_t ciot_wifi_get_scanned_ap(ciot_wifi_t self, int id, ciot_wifi_ap_info_t *ap_info);
 ciot_err_t ciot_wifi_get_scanned_aps(ciot_wifi_t self, ciot_wifi_ap_list_t *ap_list);
+ciot_err_t ciot_wifi_get_ip(ciot_wifi_t self, uint8_t ip[4]);
+ciot_err_t ciot_wifi_get_rssi(ciot_wifi_t self, int32_t *rssi);
 
 #ifdef __cplusplus
 }

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "ciot_c",
-    "version": "0.12.0",
+    "version": "0.16.0",
     "description": "Library for IoT projects",
     "keywords": ["IoT", "Automation", "TA"],
     "repository":

--- a/src/common/ciot_dfu_nrf.c
+++ b/src/common/ciot_dfu_nrf.c
@@ -60,7 +60,7 @@ struct ciot_dfu_nrf
     uint32_t data_transferred;
     ciot_dfu_nrf_object_t object;
     bool ping_refused;
-
+    bool test_mode;
     uint64_t timer;
 };
 
@@ -91,6 +91,8 @@ ciot_err_t ciot_dfu_nrf_start(ciot_dfu_nrf_t self, ciot_dfu_cfg_t *cfg)
 {
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_STATE_CHECK(self->base.status.state, CIOT_DFU_STATE_IDLE);
+
+    CIOT_LOGI(TAG, "Starting DFU nrf...");
 
     if (cfg->type != self->cfg.dfu.type)
     {
@@ -126,6 +128,13 @@ ciot_err_t ciot_dfu_nrf_stop(ciot_dfu_nrf_t self)
         .common.stop = true,
     };
     self->cfg.iface->process_data(self->cfg.iface, &data);
+    return CIOT_ERR_OK;
+}
+
+ciot_err_t ciot_dfu_nrf_set_test_mode(ciot_dfu_nrf_t self, bool enable)
+{
+    CIOT_ERR_NULL_CHECK(self);
+    self->test_mode = enable;
     return CIOT_ERR_OK;
 }
 
@@ -451,6 +460,12 @@ static ciot_err_t ciot_dfu_nrf_process_response(ciot_dfu_nrf_t self, uint8_t *da
         data[2] == CIOT_DFU_NRF_RES_CODE_SUCCESS)
     {
         CIOT_LOGI(TAG, "Ping response sucess");
+        if (self->test_mode)
+        {
+            self->state = CIOT_DFU_NRF_STATE_COMPLETED;
+            ciot_dfu_nrf_set_state(self, CIOT_DFU_STATE_COMPLETED);
+            return CIOT_ERR_OK;
+        }
         self->state = CIOT_DFU_NRF_STATE_CREATE_OBJECT;
         ciot_dfu_nrf_set_state(self, CIOT_DFU_STATE_IN_PROGRESS);
         return CIOT_ERR_OK;
@@ -585,7 +600,7 @@ static ciot_err_t ciot_dfu_nrf_set_state(ciot_dfu_nrf_t self, ciot_dfu_state_t s
 
 static ciot_err_t ciot_dfu_nrf_event_handler(ciot_iface_t *sender, ciot_event_t *event, void *args)
 {
-    CIOT_LOGD(TAG, "Event received %s", ciot_event_to_str(event));
+    CIOT_LOGI(TAG, "Event received %s", ciot_event_to_str(event));
 
     ciot_dfu_nrf_t self = (ciot_dfu_nrf_t)args;
 

--- a/src/common/ciot_eth_base.c
+++ b/src/common/ciot_eth_base.c
@@ -137,4 +137,14 @@ ciot_err_t ciot_eth_get_mac(ciot_eth_t self, uint8_t mac[6])
     return CIOT_ERR_OK;
 }
 
+ciot_err_t ciot_eth_get_ip(ciot_eth_t self, uint8_t ip[4])
+{
+    CIOT_ERR_NULL_CHECK(self);
+    CIOT_ERR_NULL_CHECK(ip);
+    ciot_eth_base_t *base = (ciot_eth_base_t*)self;
+    ciot_tcp_base_t *tcp = (ciot_tcp_base_t*)base->tcp;
+    memcpy(ip, tcp->info->ip, 4);
+    return CIOT_ERR_OK;
+}
+
 #endif // CIOT_CONFIG_FEATURE_ETH == 1

--- a/src/common/ciot_http_server_base.c
+++ b/src/common/ciot_http_server_base.c
@@ -23,12 +23,12 @@ static ciot_err_t ciot_http_server_send_data(ciot_iface_t *iface, uint8_t *data,
 ciot_err_t ciot_http_server_init(ciot_http_server_t self)
 {
     ciot_http_server_base_t *base = (ciot_http_server_base_t *)self;
-
     base->iface.ptr = self;
     base->iface.process_data = ciot_http_server_process_data;
     base->iface.get_data = ciot_http_server_get_data;
     base->iface.send_data = ciot_http_server_send_data;
     base->iface.info.type = CIOT_IFACE_TYPE_HTTP_SERVER;
+    base->custom_api.enabled = false;
     return CIOT_ERR_OK;
 }
 
@@ -43,6 +43,15 @@ ciot_err_t ciot_http_server_set_homepage(ciot_http_server_t self, ciot_http_serv
 {
     ciot_http_server_base_t *base = (ciot_http_server_base_t *)self;
     base->homepage = *homepage;
+    return CIOT_ERR_OK;
+}
+
+ciot_err_t ciot_http_server_set_custom_api(ciot_http_server_t self, ciot_http_server_custom_api_t *custom_api)
+{
+    CIOT_ERR_NULL_CHECK(self);
+    CIOT_ERR_NULL_CHECK(custom_api);
+    ciot_http_server_base_t *base = (ciot_http_server_base_t *)self;
+    base->custom_api = *custom_api;
     return CIOT_ERR_OK;
 }
 

--- a/src/common/ciot_mqtt_client_base.c
+++ b/src/common/ciot_mqtt_client_base.c
@@ -101,7 +101,10 @@ ciot_err_t ciot_mqtt_client_set_subtopic(ciot_mqtt_client_t self, char *subtopic
 ciot_mqtt_client_state_t ciot_mqtt_client_get_state(ciot_mqtt_client_t self)
 {
     ciot_mqtt_client_base_t *base = (ciot_mqtt_client_base_t*)self;
-    CIOT_ERR_NULL_CHECK(self);
+    if(self == NULL)
+    {
+        return CIOT_MQTT_CLIENT_STATE_DISCONNECTED;
+    }
     return base->status.state;
 }
 

--- a/src/common/ciot_sys_base.c
+++ b/src/common/ciot_sys_base.c
@@ -41,7 +41,6 @@ ciot_err_t ciot_sys_init(ciot_sys_t self)
     ciot_sys_get_features(&base->info.features);
 
     base->info.has_features = true;
-
     return CIOT_ERR_OK;
 }
 

--- a/src/common/ciot_wifi_base.c
+++ b/src/common/ciot_wifi_base.c
@@ -132,6 +132,7 @@ ciot_err_t ciot_wifi_get_status(ciot_wifi_t self, ciot_wifi_status_t *status)
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(status);
     ciot_wifi_base_t *base = (ciot_wifi_base_t*)self;
+    ciot_wifi_get_rssi(self, &base->status.rssi);
     *status = base->status;
     return CIOT_ERR_OK;
 }
@@ -151,6 +152,15 @@ ciot_err_t ciot_wifi_get_mac(ciot_wifi_t self, uint8_t mac[6])
     CIOT_ERR_NULL_CHECK(mac);
     ciot_wifi_base_t *base = (ciot_wifi_base_t*)self;
     memcpy(mac, base->info.tcp.mac, 6);
+    return CIOT_ERR_OK;
+}
+
+ciot_err_t ciot_wifi_get_ip(ciot_wifi_t self, uint8_t ip[4])
+{
+    CIOT_ERR_NULL_CHECK(self);
+    CIOT_ERR_NULL_CHECK(ip);
+    ciot_wifi_base_t *base = (ciot_wifi_base_t*)self;
+    memcpy(ip, base->info.tcp.ip, 4);
     return CIOT_ERR_OK;
 }
 

--- a/src/core/ciot.c
+++ b/src/core/ciot.c
@@ -661,3 +661,10 @@ static ciot_err_t ciot_bytes_received(ciot_t self, ciot_iface_t *sender, uint8_t
         return CIOT_ERR_OK;
     }
 }
+
+ciot_iface_state_t ciot_iface_get_state(ciot_t self, uint16_t iface_id)
+{
+    CIOT_ERR_NULL_CHECK(self);
+    CIOT_ERR_ID_CHECK(iface_id, self->ifaces.count);
+    return self->status.ifaces[iface_id].state;
+}

--- a/src/core/ciot.c
+++ b/src/core/ciot.c
@@ -402,9 +402,11 @@ static ciot_err_t ciot_busy_task(ciot_t self)
             // else
             // {
                 CIOT_LOGI(TAG, "Response sended");
+                ciot_event_type_t prev_type = event->type;
                 event->msg.id = sender->req_status.id;
                 event->type = CIOT_EVENT_TYPE_DONE;
                 ciot_iface_send_rsp(self->ifaces.list[sender->req_status.iface.id], &event->msg);
+                event->type = prev_type;
             // }
             sender->req_status.state = CIOT_IFACE_REQ_STATE_IDLE;
         }

--- a/src/core/ciot.c
+++ b/src/core/ciot.c
@@ -666,7 +666,9 @@ static ciot_err_t ciot_bytes_received(ciot_t self, ciot_iface_t *sender, uint8_t
 
 ciot_iface_state_t ciot_iface_get_state(ciot_t self, uint16_t iface_id)
 {
-    CIOT_ERR_NULL_CHECK(self);
-    CIOT_ERR_ID_CHECK(iface_id, self->ifaces.count);
+    if(self == NULL || iface_id >= self->ifaces.count)
+    {
+        return CIOT_IFACE_STATE_STOPPED;
+    }
     return self->status.ifaces[iface_id].state;
 }

--- a/src/default/ciot_ntp.c
+++ b/src/default/ciot_ntp.c
@@ -46,4 +46,9 @@ ciot_err_t ciot_ntp_stop(ciot_ntp_t self)
     return CIOT_ERR_NOT_IMPLEMENTED;
 }
 
+time_t ciot_ntp_first_sync_time(void)
+{
+    return 0;
+}
+
 #endif // CIOT_CONFIG_FEATURE_NTP == 1

--- a/src/default/ciot_wifi.c
+++ b/src/default/ciot_wifi.c
@@ -90,6 +90,11 @@ ciot_err_t ciot_wifi_send_bytes(ciot_iface_t *iface, uint8_t *bytes, int size)
     return CIOT_ERR_NOT_IMPLEMENTED;
 }
 
+ciot_err_t ciot_wifi_get_rssi(ciot_wifi_t self, int32_t *rssi)
+{
+    return CIOT_ERR_NOT_SUPPORTED;
+}
+
 static ciot_err_t ciot_wifi_set_cfg(ciot_wifi_t self, ciot_wifi_cfg_t *cfg)
 {
     CIOT_LOGI(TAG, "Configuring");

--- a/src/esp32/ciot_http_server.c
+++ b/src/esp32/ciot_http_server.c
@@ -33,9 +33,10 @@ struct ciot_http_server
 static const char *TAG = "ciot_http_server";
 
 static ciot_err_t ciot_https_register_routes(ciot_http_server_t self);
-static esp_err_t ciot_post_handler(httpd_req_t *req);
-static esp_err_t ciot_file_handler(httpd_req_t *req);
+static esp_err_t ciot_http_server_api_handler(httpd_req_t *req);
+static esp_err_t ciot_http_server_file_handler(httpd_req_t *req);
 static const char *get_mime_type(const char *filename);
+static esp_err_t ciot_http_server_custom_api_handler(httpd_req_t *req);
 
 ciot_http_server_t ciot_http_server_new(void *handle)
 {
@@ -56,7 +57,7 @@ ciot_err_t ciot_http_server_start(ciot_http_server_t self, ciot_http_server_cfg_
 
     httpd_config_t httpd_config = HTTPD_DEFAULT_CONFIG();
     httpd_config.server_port = cfg->port;
-    httpd_config.max_uri_handlers = 2;
+    httpd_config.max_uri_handlers = 3;
     httpd_config.uri_match_fn = httpd_uri_match_wildcard;
     httpd_config.stack_size = 8192;
 
@@ -93,7 +94,7 @@ static ciot_err_t ciot_https_register_routes(ciot_http_server_t self)
     CIOT_LOGI(TAG, "Registering route: %s", self->base.cfg.route);
     httpd_uri_t post_uri = {
         .uri = self->base.cfg.route,
-        .handler = ciot_post_handler,
+        .handler = ciot_http_server_api_handler,
         .method = HTTP_POST,
         .user_ctx = self,
     };
@@ -104,10 +105,28 @@ static ciot_err_t ciot_https_register_routes(ciot_http_server_t self)
         return CIOT_ERR_FAIL;
     }
 
+    if (self->base.custom_api.enabled && self->base.custom_api.handler != NULL)
+    {
+        CIOT_LOGI(TAG, "Registering route: %s", self->base.custom_api.uri);
+        httpd_uri_t post_uri = {
+            .uri = self->base.custom_api.uri,
+            .handler = ciot_http_server_custom_api_handler,
+            .method = HTTP_ANY,
+            .user_ctx = self,
+        };
+        esp_err_t err = httpd_register_uri_handler(self->handle, &post_uri);
+        if (err)
+        {
+            CIOT_LOGE(TAG, "Register uri error: %s", esp_err_to_name(err));
+            return CIOT_ERR_FAIL;
+        }
+    }
+
+    CIOT_LOGI(TAG, "Registering route: /*");
     httpd_uri_t file_uri = {
-        .uri = "/*", // Captura todas as URIs
+        .uri = "/*",
         .method = HTTP_GET,
-        .handler = ciot_file_handler,
+        .handler = ciot_http_server_file_handler,
         .user_ctx = self};
     err = httpd_register_uri_handler(self->handle, &file_uri);
     if (err)
@@ -118,7 +137,7 @@ static ciot_err_t ciot_https_register_routes(ciot_http_server_t self)
     return CIOT_ERR_OK;
 }
 
-static esp_err_t ciot_post_handler(httpd_req_t *req)
+static esp_err_t ciot_http_server_api_handler(httpd_req_t *req)
 {
     ciot_http_server_t self = (ciot_http_server_t)req->user_ctx;
     ciot_event_t event = {0};
@@ -166,7 +185,7 @@ static esp_err_t ciot_post_handler(httpd_req_t *req)
     return CIOT_ERR_OK;
 }
 
-static esp_err_t ciot_file_handler(httpd_req_t *req)
+static esp_err_t ciot_http_server_file_handler(httpd_req_t *req)
 {
     ciot_http_server_t self = (ciot_http_server_t)req->user_ctx;
 
@@ -176,7 +195,7 @@ static esp_err_t ciot_file_handler(httpd_req_t *req)
 
     if (((strcmp(req->uri, "/") == 0) || (strcmp(req->uri, "/index.html") == 0)) && self->base.homepage.size > 0)
     {
-        if(self->base.homepage.gz)
+        if (self->base.homepage.gz)
         {
             CIOT_LOGI(TAG, "Serving embed gzip");
             httpd_resp_set_hdr(req, "Content-Encoding", "gzip");
@@ -269,6 +288,75 @@ static const char *get_mime_type(const char *filename)
     if (strstr(filename, ".svg"))
         return "image/svg+xml";
     return "text/plain";
+}
+
+static esp_err_t ciot_http_server_custom_api_handler(httpd_req_t *req)
+{
+    ciot_http_server_t self = (ciot_http_server_t)req->user_ctx;
+    ciot_event_t event = {0};
+
+    if (self == NULL)
+    {
+        CIOT_LOGE(TAG, "Null context");
+        return ESP_FAIL;
+    }
+
+    httpd_req_recv(req, (char *)event.raw.bytes, req->content_len);
+
+    switch (req->method)
+    {
+    case HTTP_DELETE:
+        self->base.custom_api.handler(self, req->uri, strlen(req->uri), "DELETE", event.raw.bytes, req->content_len, self->base.custom_api.args);
+        break;
+    case HTTP_GET:
+        self->base.custom_api.handler(self, req->uri, strlen(req->uri), "GET", event.raw.bytes, req->content_len, self->base.custom_api.args);
+        break;
+    case HTTP_HEAD:
+        self->base.custom_api.handler(self, req->uri, strlen(req->uri), "HEAD", event.raw.bytes, req->content_len, self->base.custom_api.args);
+        break;
+    case HTTP_POST:
+        self->base.custom_api.handler(self, req->uri, strlen(req->uri), "POST", event.raw.bytes, req->content_len, self->base.custom_api.args);
+        break;
+    case HTTP_PUT:
+        self->base.custom_api.handler(self, req->uri, strlen(req->uri), "PUT", event.raw.bytes, req->content_len, self->base.custom_api.args);
+        break;
+    case HTTP_CONNECT:
+        self->base.custom_api.handler(self, req->uri, strlen(req->uri), "CONNECT", event.raw.bytes, req->content_len, self->base.custom_api.args);
+        break;
+    default:
+        self->base.custom_api.handler(self, req->uri, strlen(req->uri), "UNKNOWN", event.raw.bytes, req->content_len, self->base.custom_api.args);
+        break;
+    }
+
+    if (self->resp_size == 0)
+    {
+        xEventGroupClearBits(self->event_group, CIOT_HTTP_SERVER_RESP_READY_BIT);
+        xEventGroupWaitBits(
+            self->event_group,
+            CIOT_HTTP_SERVER_RESP_READY_BIT,
+            pdTRUE,
+            pdFALSE,
+            pdMS_TO_TICKS(CIOT_HTTP_SERVER_TIMEOUT_MS));
+    }
+
+    if (self->resp_size > 0)
+    {
+        CIOT_LOGI(TAG, "Resp OK");
+        httpd_resp_set_status(req, HTTPD_200);
+        httpd_resp_set_type(req, HTTPD_TYPE_OCTET);
+#ifdef CIOT_CONFIG_HTTP_SERVER_ALLOW_ORIGIN
+        httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", CIOT_CONFIG_HTTP_SERVER_ALLOW_ORIGIN);
+#endif
+        httpd_resp_send(req, (const char *)self->resp, self->resp_size);
+        self->resp_size = 0;
+    }
+    else
+    {
+        CIOT_LOGW(TAG, "Timeout waiting for response");
+        httpd_resp_send_500(req);
+    }
+
+    return CIOT_ERR_OK;
 }
 
 #endif //! CIOT_CONFIG_FEATURE_HTTP_SERVER == 1

--- a/src/esp32/ciot_ntp.c
+++ b/src/esp32/ciot_ntp.c
@@ -20,6 +20,8 @@
 
 static const char *TAG = "ciot_ntp";
 
+static time_t first_sync_time = 0;
+
 struct ciot_ntp
 {
     ciot_ntp_base_t base;
@@ -93,6 +95,11 @@ ciot_err_t ciot_ntp_stop(ciot_ntp_t self)
     return CIOT_ERR_OK;
 }
 
+time_t ciot_ntp_first_sync_time(void)
+{
+    return first_sync_time;
+}
+
 static void ciot_ntp_sync_notification_cb(struct timeval *tv)
 {
     CIOT_LOGI(TAG, "Started");
@@ -102,6 +109,10 @@ static void ciot_ntp_sync_notification_cb(struct timeval *tv)
     base->status.sync = 1;
     base->status.sync_count++;
     base->status.last_sync = ciot_timer_now();
+    if(first_sync_time == 0)
+    {
+        first_sync_time = ciot_timer_now();
+    }   
     ciot_iface_send_event_type(&base->iface, CIOT_EVENT_TYPE_STARTED);
 }
 

--- a/src/esp32/ciot_storage_auto.c
+++ b/src/esp32/ciot_storage_auto.c
@@ -22,13 +22,17 @@
 #include "ciot_storage.h"
 #include "ciot_storage_fs.h"
 #include "ciot_storage_fat.h"
-#include "ciot_storage_spiffs.c"
+#include "ciot_storage_spiffs.h"
 
 typedef struct ciot_storage_auto *ciot_storage_auto_t;
 
-ciot_storage_t ciot_storage_auto_new(void)
+ciot_storage_t ciot_storage_auto_new(const char *label)
 {
-    const esp_partition_t* partition = esp_partition_find_first(ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_ANY, FS_PARTITION_LABLE);
+    const esp_partition_t* partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, "storage");
+
+    if(partition == NULL) {
+        return NULL;
+    }
 
     switch (partition->subtype)
     {

--- a/src/esp32/ciot_sys.c
+++ b/src/esp32/ciot_sys.c
@@ -18,6 +18,7 @@
 #include "ciot_sys.h"
 #include "ciot_timer.h"
 #include "ciot_err.h"
+#include "ciot_ntp.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"
 
@@ -26,7 +27,6 @@
 struct ciot_sys
 {
     ciot_sys_base_t base;
-    uint64_t init_time;
     EventGroupHandle_t event_group;
 };
 
@@ -70,7 +70,7 @@ ciot_err_t ciot_sys_task(ciot_sys_t self)
 {
     ciot_sys_base_t *base = &self->base;
     base->status.free_memory = esp_get_free_heap_size();
-    base->status.lifetime = ciot_timer_now() - self->init_time;
+    base->status.lifetime = ciot_timer_now() - ciot_ntp_first_sync_time();
     xEventGroupWaitBits(self->event_group, CIOT_SYS_EVT_BIT_POOLING, pdTRUE, pdTRUE, pdMS_TO_TICKS(CIOT_SYS_DEFAULT_POOLING_INTERVAL_MS));
     return CIOT_ERR_OK;
 }

--- a/src/esp32/ciot_sys.c
+++ b/src/esp32/ciot_sys.c
@@ -71,7 +71,7 @@ ciot_err_t ciot_sys_task(ciot_sys_t self)
     ciot_sys_base_t *base = &self->base;
     base->status.free_memory = esp_get_free_heap_size();
     base->status.lifetime = ciot_timer_now() - self->init_time;
-    xEventGroupWaitBits(self->event_group, CIOT_SYS_EVT_BIT_POOLING, pdTRUE, pdTRUE, pdMS_TO_TICKS(100));
+    xEventGroupWaitBits(self->event_group, CIOT_SYS_EVT_BIT_POOLING, pdTRUE, pdTRUE, pdMS_TO_TICKS(CIOT_SYS_DEFAULT_POOLING_INTERVAL_MS));
     return CIOT_ERR_OK;
 }
 

--- a/src/esp32/ciot_wifi.c
+++ b/src/esp32/ciot_wifi.c
@@ -172,9 +172,12 @@ ciot_err_t ciot_wifi_get_rssi(ciot_wifi_t self, int32_t *rssi)
 {
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(rssi);
-    wifi_ap_record_t ap_info = { 0 };
-    esp_wifi_sta_get_ap_info(&ap_info);
-    *rssi = ap_info.rssi;
+    if(self->base.status.tcp.state == CIOT_TCP_STATE_CONNECTED)
+    {
+        wifi_ap_record_t ap_info = { 0 };
+        esp_wifi_sta_get_ap_info(&ap_info);
+        *rssi = ap_info.rssi;
+    }
     return CIOT_ERR_OK;
 }
 

--- a/src/esp32/ciot_wifi.c
+++ b/src/esp32/ciot_wifi.c
@@ -168,6 +168,16 @@ ciot_err_t ciot_wifi_scan(ciot_wifi_t self)
     return esp_wifi_scan_start(NULL, false);
 }
 
+ciot_err_t ciot_wifi_get_rssi(ciot_wifi_t self, int32_t *rssi)
+{
+    CIOT_ERR_NULL_CHECK(self);
+    CIOT_ERR_NULL_CHECK(rssi);
+    wifi_ap_record_t ap_info = { 0 };
+    esp_wifi_sta_get_ap_info(&ap_info);
+    *rssi = ap_info.rssi;
+    return CIOT_ERR_OK;
+}
+
 static esp_err_t esp_wifi_init_mode(ciot_wifi_type_t type)
 {
     wifi_mode_t mode;
@@ -395,10 +405,12 @@ static void ciot_wifi_sta_event_handler(void *handler_args, esp_event_base_t eve
         tcp->status->state = CIOT_TCP_STATE_CONNECTED;
         tcp->status->conn_count++;
         base->status.disconnect_reason = 0;
+        base->info.has_ap = true;
         base->info.ap.authmode = data->authmode;
         memcpy(base->info.ap.bssid, data->bssid, sizeof(data->bssid));
         memcpy(base->info.ap.ssid, data->ssid, sizeof(data->ssid));
         self->reconnecting = false;
+        ciot_wifi_get_rssi(self, &base->status.rssi);
         CIOT_ERR_PRINT(TAG, ciot_tcp_start(base->tcp));
         break;
     }

--- a/src/esp8266/ciot_ntp.c
+++ b/src/esp8266/ciot_ntp.c
@@ -26,6 +26,7 @@ struct ciot_ntp
 };
 
 void *notif_args;
+time_t first_sync_time = 0;
 
 static void ciot_ntp_sync_notification_cb(struct timeval *tv);
 
@@ -98,6 +99,11 @@ ciot_err_t ciot_ntp_stop(ciot_ntp_t self)
     return CIOT_ERR_OK;
 }
 
+time_t ciot_ntp_first_sync_time(void)
+{
+    return first_sync_time;
+}
+
 static void ciot_ntp_sync_notification_cb(struct timeval *tv)
 {
     CIOT_LOGI(TAG, "Started");
@@ -108,6 +114,10 @@ static void ciot_ntp_sync_notification_cb(struct timeval *tv)
     base->status.sync = 1;
     base->status.sync_count++;
     base->status.last_sync = ciot_timer_now();
+    if (first_sync_time == 0)
+    {
+        first_sync_time = ciot_timer_now();
+    }
     ciot_iface_send_event_type(&base->iface, CIOT_EVENT_TYPE_STARTED);
 }
 

--- a/src/esp8266/ciot_storage_auto.c
+++ b/src/esp8266/ciot_storage_auto.c
@@ -26,17 +26,28 @@
 
 typedef struct ciot_storage_auto *ciot_storage_auto_t;
 
+static const char *TAG = "ciot_storage_auto";
+
 ciot_storage_t ciot_storage_auto_new(void)
 {
     const esp_partition_t* partition = esp_partition_find_first(ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_ANY, FS_PARTITION_LABLE);
 
+    if(partition == NULL)
+    {
+        CIOT_LOGE(TAG, "No storage partition found");
+        return NULL;
+    }
+
     switch (partition->subtype)
     {
     case ESP_PARTITION_SUBTYPE_DATA_FAT:
+        CIOT_LOGI(TAG, "Using FAT storage");
         return ciot_storage_fat_new();
     case ESP_PARTITION_SUBTYPE_DATA_SPIFFS:
+        CIOT_LOGI(TAG, "Using SPIFFS storage");
         return ciot_storage_spiffs_new();
     default:
+        CIOT_LOGE(TAG, "No valid storage partition found");
         return NULL;
     }
 }

--- a/src/esp8266/ciot_sys.c
+++ b/src/esp8266/ciot_sys.c
@@ -71,7 +71,7 @@
      ciot_sys_base_t *base = &self->base;
      base->status.free_memory = esp_get_free_heap_size();
      base->status.lifetime = ciot_timer_now() - self->init_time;
-     xEventGroupWaitBits(self->event_group, CIOT_SYS_EVT_BIT_POOLING, pdTRUE, pdTRUE, pdMS_TO_TICKS(100));
+     xEventGroupWaitBits(self->event_group, CIOT_SYS_EVT_BIT_POOLING, pdTRUE, pdTRUE, pdMS_TO_TICKS(CIOT_SYS_DEFAULT_POOLING_INTERVAL_MS));
      return CIOT_ERR_OK;
  }
  

--- a/src/esp8266/ciot_sys.c
+++ b/src/esp8266/ciot_sys.c
@@ -10,6 +10,7 @@
  */
 
  #include "ciot_config.h"
+ #include "ciot_ntp.h"
 
  #if CIOT_CONFIG_FEATURE_SYS == 1 && defined(CIOT_PLATFORM_ESP8266)
  
@@ -26,7 +27,6 @@
  struct ciot_sys
  {
      ciot_sys_base_t base;
-     uint64_t init_time;
      EventGroupHandle_t event_group;
  };
  
@@ -70,7 +70,7 @@
  {
      ciot_sys_base_t *base = &self->base;
      base->status.free_memory = esp_get_free_heap_size();
-     base->status.lifetime = ciot_timer_now() - self->init_time;
+     base->status.lifetime = ciot_timer_now() - ciot_ntp_first_sync_time();
      xEventGroupWaitBits(self->event_group, CIOT_SYS_EVT_BIT_POOLING, pdTRUE, pdTRUE, pdMS_TO_TICKS(CIOT_SYS_DEFAULT_POOLING_INTERVAL_MS));
      return CIOT_ERR_OK;
  }

--- a/src/esp8266/ciot_wifi.c
+++ b/src/esp8266/ciot_wifi.c
@@ -168,6 +168,16 @@ ciot_err_t ciot_wifi_scan(ciot_wifi_t self)
     return esp_wifi_scan_start(NULL, false);
 }
 
+ciot_err_t ciot_wifi_get_rssi(ciot_wifi_t self, int32_t *rssi)
+{
+    CIOT_ERR_NULL_CHECK(self);
+    CIOT_ERR_NULL_CHECK(rssi);
+    wifi_ap_record_t ap_info = { 0 };
+    esp_wifi_sta_get_ap_info(&ap_info);
+    *rssi = ap_info.rssi;
+    return CIOT_ERR_OK;
+}
+
 static esp_err_t esp_wifi_init_mode(ciot_wifi_type_t type)
 {
     wifi_mode_t mode;

--- a/src/linux/ciot_ntp.c
+++ b/src/linux/ciot_ntp.c
@@ -46,4 +46,9 @@ ciot_err_t ciot_ntp_stop(ciot_ntp_t self)
     return CIOT_ERR_NOT_SUPPORTED;
 }
 
+time_t ciot_ntp_first_sync_time(void)
+{
+    return 0;
+}
+
 #endif // CIOT_CONFIG_FEATURE_NTP == 1

--- a/src/linux/ciot_ntp.c
+++ b/src/linux/ciot_ntp.c
@@ -15,6 +15,7 @@
 
 #include <stdlib.h>
 #include "ciot_ntp.h"
+#include "ciot_timer.h"
 
 // static const char *TAG = "ciot_ntp";
 
@@ -24,6 +25,7 @@ struct ciot_ntp
 };
 
 void *notif_args;
+static time_t first_sync_time = 0;
 
 ciot_ntp_t ciot_ntp_new(void *handle)
 {
@@ -36,7 +38,7 @@ ciot_err_t ciot_ntp_start(ciot_ntp_t self, ciot_ntp_cfg_t *cfg)
 {
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(cfg);
-
+    first_sync_time = ciot_timer_now();
     return CIOT_ERR_NOT_SUPPORTED;
 }
 
@@ -48,7 +50,7 @@ ciot_err_t ciot_ntp_stop(ciot_ntp_t self)
 
 time_t ciot_ntp_first_sync_time(void)
 {
-    return 0;
+    return first_sync_time;
 }
 
 #endif // CIOT_CONFIG_FEATURE_NTP == 1

--- a/src/linux/ciot_sys.c
+++ b/src/linux/ciot_sys.c
@@ -22,6 +22,7 @@
 #include "ciot_err.h"
 #include "ciot_timer.h"
 #include "mongoose.h"
+#include "ciot_ntp.h"
 
 static const char *TAG = "ciot_sys";
 

--- a/src/linux/ciot_sys.c
+++ b/src/linux/ciot_sys.c
@@ -28,7 +28,6 @@ static const char *TAG = "ciot_sys";
 struct ciot_sys
 {
     ciot_sys_base_t base;
-    time_t init_time;
 };
 
 static uint32_t ciot_sys_get_free_ram(void);
@@ -47,7 +46,6 @@ ciot_sys_t ciot_sys_new(void *handle)
 ciot_err_t ciot_sys_start(ciot_sys_t self, ciot_sys_cfg_t *cfg)
 {
     CIOT_ERR_NULL_CHECK(self);
-    self->init_time = ciot_timer_now();
     return ciot_iface_send_event_type(&self->base.iface, CIOT_EVENT_TYPE_STARTED);
 }
 
@@ -62,7 +60,7 @@ ciot_err_t ciot_sys_task(ciot_sys_t self)
 {
     CIOT_ERR_NULL_CHECK(self);
     sys->base.status.free_memory = ciot_sys_get_free_ram();
-    sys->base.status.lifetime = ciot_timer_now() - sys->init_time;
+    sys->base.status.lifetime = ciot_timer_now();
     return CIOT_ERR_OK;
 }
 

--- a/src/linux/ciot_wifi.c
+++ b/src/linux/ciot_wifi.c
@@ -95,6 +95,11 @@ ciot_err_t ciot_wifi_send_bytes(ciot_iface_t *iface, uint8_t *bytes, int size)
     return CIOT_ERR_NOT_SUPPORTED;
 }
 
+ciot_err_t ciot_wifi_get_rssi(ciot_wifi_t self, int32_t *rssi)
+{
+    return CIOT_ERR_NOT_SUPPORTED;
+}
+
 static ciot_err_t ciot_wifi_set_cfg(ciot_wifi_t self, ciot_wifi_cfg_t *cfg)
 {
     CIOT_LOGI(TAG, "Configuring");

--- a/src/mg/ciot_http_server.c
+++ b/src/mg/ciot_http_server.c
@@ -139,6 +139,10 @@ static void ciot_http_server_event_handler(struct mg_connection *c, int ev, void
             event.raw.size = hm->body.len;
             ciot_iface_send_event(&base->iface, &event);
         }
+        else if(self->base.custom_api.enabled && mg_match(hm->uri, mg_str(self->base.custom_api.uri), NULL))
+        {
+            self->base.custom_api.handler(self, hm->uri.buf, hm->uri.len, hm->method.buf, (uint8_t *)hm->body.buf, hm->body.len, self->base.custom_api.args);
+        }
         else if (mg_match(hm->uri, mg_str("/"), NULL) && check_method(hm, "GET") && base->homepage.size > 0)
         {
             mg_printf(self->conn_tx,

--- a/src/protos/ciot/proto/v2/msg.pb.h
+++ b/src/protos/ciot/proto/v2/msg.pb.h
@@ -30,6 +30,7 @@ typedef struct ciot_proxy {
     bool has_iface;
     ciot_iface_info_t iface; /* Proxy interface information. */
     ciot_proxy_state_t state; /* Proxy state. */
+    bool save; /* Use ciot to save msg data */
 } ciot_proxy_t;
 
 /* Represents an CioT message */
@@ -72,14 +73,15 @@ extern "C" {
 
 
 /* Initializer values for message structs */
-#define CIOT_PROXY_INIT_DEFAULT                  {false, CIOT_IFACE_INFO_INIT_DEFAULT, _CIOT_PROXY_STATE_MIN}
+#define CIOT_PROXY_INIT_DEFAULT                  {false, CIOT_IFACE_INFO_INIT_DEFAULT, _CIOT_PROXY_STATE_MIN, 0}
 #define CIOT_MSG_INIT_DEFAULT                    {0, false, CIOT_IFACE_INFO_INIT_DEFAULT, _CIOT_ERR_MIN, false, CIOT_MSG_DATA_INIT_DEFAULT, _CIOT_MSG_TYPE_MIN, false, CIOT_PROXY_INIT_DEFAULT}
-#define CIOT_PROXY_INIT_ZERO                     {false, CIOT_IFACE_INFO_INIT_ZERO, _CIOT_PROXY_STATE_MIN}
+#define CIOT_PROXY_INIT_ZERO                     {false, CIOT_IFACE_INFO_INIT_ZERO, _CIOT_PROXY_STATE_MIN, 0}
 #define CIOT_MSG_INIT_ZERO                       {0, false, CIOT_IFACE_INFO_INIT_ZERO, _CIOT_ERR_MIN, false, CIOT_MSG_DATA_INIT_ZERO, _CIOT_MSG_TYPE_MIN, false, CIOT_PROXY_INIT_ZERO}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define CIOT_PROXY_IFACE_TAG                     1
 #define CIOT_PROXY_STATE_TAG                     2
+#define CIOT_PROXY_SAVE_TAG                      3
 #define CIOT_MSG_ID_TAG                          1
 #define CIOT_MSG_IFACE_TAG                       2
 #define CIOT_MSG_ERROR_TAG                       3
@@ -90,7 +92,8 @@ extern "C" {
 /* Struct field encoding specification for nanopb */
 #define CIOT_PROXY_FIELDLIST(X, a) \
 X(a, STATIC,   OPTIONAL, MESSAGE,  iface,             1) \
-X(a, STATIC,   SINGULAR, UENUM,    state,             2)
+X(a, STATIC,   SINGULAR, UENUM,    state,             2) \
+X(a, STATIC,   SINGULAR, BOOL,     save,              3)
 #define CIOT_PROXY_CALLBACK NULL
 #define CIOT_PROXY_DEFAULT NULL
 #define ciot_proxy_t_iface_MSGTYPE ciot_iface_info_t
@@ -116,10 +119,10 @@ extern const pb_msgdesc_t ciot_msg_t_msg;
 #define CIOT_MSG_FIELDS &ciot_msg_t_msg
 
 /* Maximum encoded size of messages (where known) */
-#define CIOT_PROXY_SIZE                          12
+#define CIOT_PROXY_SIZE                          14
 #if defined(Ciot_MsgData_size)
 #define CIOT_CIOT_PROTO_V2_MSG_PB_H_MAX_SIZE     CIOT_MSG_SIZE
-#define CIOT_MSG_SIZE                            (40 + Ciot_MsgData_size)
+#define CIOT_MSG_SIZE                            (42 + Ciot_MsgData_size)
 #endif
 
 #ifdef __cplusplus

--- a/src/protos/ciot/proto/v2/wifi.pb.h
+++ b/src/protos/ciot/proto/v2/wifi.pb.h
@@ -55,6 +55,7 @@ typedef struct ciot_wifi_status {
     bool has_tcp;
     ciot_tcp_status_t tcp; /* Status of the TCP connection over Wi-Fi. */
     ciot_wifi_scan_state_t scan_state; /* Wi-Fi scan state */
+    int32_t rssi; /* Received Signal Strength Indicator (RSSI) */
 } ciot_wifi_status_t;
 
 typedef struct ciot_wifi_info {
@@ -139,7 +140,7 @@ extern "C" {
 #define CIOT_WIFI_AP_INFO_INIT_DEFAULT           {{0}, "", 0, 0}
 #define CIOT_WIFI_STOP_INIT_DEFAULT              {0}
 #define CIOT_WIFI_CFG_INIT_DEFAULT               {0, "", "", _CIOT_WIFI_TYPE_MIN, false, CIOT_TCP_CFG_INIT_DEFAULT}
-#define CIOT_WIFI_STATUS_INIT_DEFAULT            {0, false, CIOT_TCP_STATUS_INIT_DEFAULT, _CIOT_WIFI_SCAN_STATE_MIN}
+#define CIOT_WIFI_STATUS_INIT_DEFAULT            {0, false, CIOT_TCP_STATUS_INIT_DEFAULT, _CIOT_WIFI_SCAN_STATE_MIN, 0}
 #define CIOT_WIFI_INFO_INIT_DEFAULT              {false, CIOT_TCP_INFO_INIT_DEFAULT, false, CIOT_WIFI_AP_INFO_INIT_DEFAULT}
 #define CIOT_WIFI_REQ_SCAN_INIT_DEFAULT          {0}
 #define CIOT_WIFI_REQ_SCAN_RESULT_INIT_DEFAULT   {0}
@@ -149,7 +150,7 @@ extern "C" {
 #define CIOT_WIFI_AP_INFO_INIT_ZERO              {{0}, "", 0, 0}
 #define CIOT_WIFI_STOP_INIT_ZERO                 {0}
 #define CIOT_WIFI_CFG_INIT_ZERO                  {0, "", "", _CIOT_WIFI_TYPE_MIN, false, CIOT_TCP_CFG_INIT_ZERO}
-#define CIOT_WIFI_STATUS_INIT_ZERO               {0, false, CIOT_TCP_STATUS_INIT_ZERO, _CIOT_WIFI_SCAN_STATE_MIN}
+#define CIOT_WIFI_STATUS_INIT_ZERO               {0, false, CIOT_TCP_STATUS_INIT_ZERO, _CIOT_WIFI_SCAN_STATE_MIN, 0}
 #define CIOT_WIFI_INFO_INIT_ZERO                 {false, CIOT_TCP_INFO_INIT_ZERO, false, CIOT_WIFI_AP_INFO_INIT_ZERO}
 #define CIOT_WIFI_REQ_SCAN_INIT_ZERO             {0}
 #define CIOT_WIFI_REQ_SCAN_RESULT_INIT_ZERO      {0}
@@ -170,6 +171,7 @@ extern "C" {
 #define CIOT_WIFI_STATUS_DISCONNECT_REASON_TAG   1
 #define CIOT_WIFI_STATUS_TCP_TAG                 2
 #define CIOT_WIFI_STATUS_SCAN_STATE_TAG          3
+#define CIOT_WIFI_STATUS_RSSI_TAG                4
 #define CIOT_WIFI_INFO_TCP_TAG                   1
 #define CIOT_WIFI_INFO_AP_TAG                    2
 #define CIOT_WIFI_REQ_SCAN_RESULT_COUNT_TAG      1
@@ -211,7 +213,8 @@ X(a, STATIC,   OPTIONAL, MESSAGE,  tcp,               5)
 #define CIOT_WIFI_STATUS_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, UINT32,   disconnect_reason,   1) \
 X(a, STATIC,   OPTIONAL, MESSAGE,  tcp,               2) \
-X(a, STATIC,   SINGULAR, UENUM,    scan_state,        3)
+X(a, STATIC,   SINGULAR, UENUM,    scan_state,        3) \
+X(a, STATIC,   SINGULAR, INT32,    rssi,              4)
 #define CIOT_WIFI_STATUS_CALLBACK NULL
 #define CIOT_WIFI_STATUS_DEFAULT NULL
 #define ciot_wifi_status_t_tcp_MSGTYPE ciot_tcp_status_t
@@ -298,7 +301,7 @@ extern const pb_msgdesc_t ciot_wifi_data_t_msg;
 #define CIOT_WIFI_REQ_SCAN_RESULT_SIZE           6
 #define CIOT_WIFI_REQ_SCAN_SIZE                  0
 #define CIOT_WIFI_REQ_SIZE                       65
-#define CIOT_WIFI_STATUS_SIZE                    24
+#define CIOT_WIFI_STATUS_SIZE                    35
 #define CIOT_WIFI_STOP_SIZE                      0
 
 #ifdef __cplusplus

--- a/src/win/ciot_ntp.c
+++ b/src/win/ciot_ntp.c
@@ -15,6 +15,7 @@
 
 #include <stdlib.h>
 #include "ciot_ntp.h"
+#include "ciot_timer.h"
 
 // static const char *TAG = "ciot_ntp";
 
@@ -24,6 +25,7 @@ struct ciot_ntp
 };
 
 void *notif_args;
+static time_t first_sync_time = 0;
 
 ciot_ntp_t ciot_ntp_new(void *handle)
 {
@@ -36,7 +38,7 @@ ciot_err_t ciot_ntp_start(ciot_ntp_t self, ciot_ntp_cfg_t *cfg)
 {
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(cfg);
-
+    first_sync_time = ciot_timer_now();
     return CIOT_ERR_NOT_SUPPORTED;
 }
 
@@ -44,6 +46,11 @@ ciot_err_t ciot_ntp_stop(ciot_ntp_t self)
 {
     CIOT_ERR_NULL_CHECK(self);
     return CIOT_ERR_NOT_SUPPORTED;
+}
+
+time_t ciot_ntp_first_sync_time(void)
+{
+    return first_sync_time;
 }
 
 #endif // CIOT_CONFIG_FEATURE_NTP == 1

--- a/src/win/ciot_sys.c
+++ b/src/win/ciot_sys.c
@@ -28,7 +28,6 @@ static const char *TAG = "ciot_sys";
 struct ciot_sys
 {
     ciot_sys_base_t base;
-    time_t init_time;
 };
 
 static uint32_t ciot_sys_get_free_ram(void);
@@ -47,7 +46,6 @@ ciot_sys_t ciot_sys_new(void *handle)
 ciot_err_t ciot_sys_start(ciot_sys_t self, ciot_sys_cfg_t *cfg)
 {
     CIOT_ERR_NULL_CHECK(self);
-    self->init_time = ciot_timer_now();
     return ciot_iface_send_event_type(&self->base.iface, CIOT_EVENT_TYPE_STARTED);
 }
 
@@ -62,7 +60,7 @@ ciot_err_t ciot_sys_task(ciot_sys_t self)
 {
     CIOT_ERR_NULL_CHECK(self);
     sys->base.status.free_memory = ciot_sys_get_free_ram();
-    sys->base.status.lifetime = ciot_timer_now() - sys->init_time;
+    sys->base.status.lifetime = ciot_timer_now();
     return CIOT_ERR_OK;
 }
 

--- a/src/win/ciot_sys.c
+++ b/src/win/ciot_sys.c
@@ -21,6 +21,7 @@
 #include "ciot_sys.h"
 #include "ciot_err.h"
 #include "ciot_timer.h"
+#include "ciot_ntp.h"
 #include "mongoose.h"
 
 static const char *TAG = "ciot_sys";
@@ -60,7 +61,7 @@ ciot_err_t ciot_sys_task(ciot_sys_t self)
 {
     CIOT_ERR_NULL_CHECK(self);
     sys->base.status.free_memory = ciot_sys_get_free_ram();
-    sys->base.status.lifetime = ciot_timer_now();
+    sys->base.status.lifetime = ciot_timer_now() - ciot_ntp_first_sync_time();
     return CIOT_ERR_OK;
 }
 

--- a/src/win/ciot_wifi.c
+++ b/src/win/ciot_wifi.c
@@ -79,6 +79,11 @@ ciot_err_t ciot_wifi_send_bytes(ciot_iface_t *iface, uint8_t *bytes, int size)
     return CIOT_ERR_NOT_SUPPORTED;
 }
 
+ciot_err_t ciot_wifi_get_rssi(ciot_wifi_t self, int32_t *rssi)
+{
+    return CIOT_ERR_NOT_SUPPORTED;
+}
+
 static ciot_err_t ciot_wifi_set_cfg(ciot_wifi_t self, ciot_wifi_cfg_t *cfg)
 {
     CIOT_LOGI(TAG, "Configuring");


### PR DESCRIPTION
This pull request introduces several significant enhancements and new features across the CIOT codebase, focusing on extensibility, device management, and improved API consistency. The most notable changes include support for custom HTTP API endpoints, new APIs for network interface status, improvements to device firmware update (DFU) logic, and a unified approach to NTP time tracking and system lifetime calculation. Additionally, the release version is updated to 0.16.0.

**HTTP Server Customization:**

- Added support for registering custom API endpoints in the HTTP server. This includes a new handler type (`ciot_http_server_custom_api_handler_fn`), associated data structures, and runtime enable/disable and route handling. This allows users to define and process their own HTTP API endpoints through the CIOT HTTP server. [[1]](diffhunk://#diff-0541a2b7e298ac99ae17f17d35f0e8435e2b998bbefcb7a3cf6db8b511746db9L5-R55) [[2]](diffhunk://#diff-30be0adb0cad3dca9597199fc8e81a0da02c60e787a149fc2f378b9ea209fc1cR24-R25) [[3]](diffhunk://#diff-30be0adb0cad3dca9597199fc8e81a0da02c60e787a149fc2f378b9ea209fc1cR43-R57) [[4]](diffhunk://#diff-30be0adb0cad3dca9597199fc8e81a0da02c60e787a149fc2f378b9ea209fc1cR69) [[5]](diffhunk://#diff-c177ce0c72f538dbaee642d82ed4a16a68060a6fc05da2b6932c167920cea1f7L26-R31) [[6]](diffhunk://#diff-c177ce0c72f538dbaee642d82ed4a16a68060a6fc05da2b6932c167920cea1f7R49-R57)

**Network Interface Enhancements:**

- Added APIs to retrieve the current IP address for Ethernet (`ciot_eth_get_ip`) and WiFi (`ciot_wifi_get_ip`), and to query WiFi signal strength (`ciot_wifi_get_rssi`). These are implemented in both headers and source files. [[1]](diffhunk://#diff-0541a2b7e298ac99ae17f17d35f0e8435e2b998bbefcb7a3cf6db8b511746db9L5-R55) [[2]](diffhunk://#diff-fa4523ff179274410ba9796738b1f504e59afa76563a8ee1b0afabb9a6ce640eR37) [[3]](diffhunk://#diff-10c27a04ab9edf24529f28f38b31250b422c7699ec0d9c9a1a1c7fae81747629R140-R149) [[4]](diffhunk://#diff-ca06c9e501fbf825c6fd9ca3cd0cce0ce9db4ddb5c48c00c94d2c023ccb800d0R60-R61)
- WiFi status retrieval now includes the latest RSSI value, and WiFi connection events update RSSI and AP info.

**DFU (Device Firmware Update) Improvements:**

- Introduced a "test mode" to the Nordic DFU implementation, with new struct members, API (`ciot_dfu_nrf_set_test_mode`), and logic for immediate completion of ping responses and state transitions in test mode. Improved logging for DFU events and start operations. [[1]](diffhunk://#diff-0541a2b7e298ac99ae17f17d35f0e8435e2b998bbefcb7a3cf6db8b511746db9L5-R55) [[2]](diffhunk://#diff-74a286d93b9147cda2e796082ebafd561f5ffe864b6e7ef62c25a6043764bb84R102) [[3]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793L63-R63) [[4]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R95-R96) [[5]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R134-R140) [[6]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793R463-R468) [[7]](diffhunk://#diff-fbe65a7e710b59bf67db57d1d53ed72fe347e8ea6b9729c6ce64008109b8f793L588-R603)

**NTP and System Lifetime Improvements:**

- Added `ciot_ntp_first_sync_time()` API to all platforms to provide the timestamp of the first successful NTP sync, replacing previous per-platform mechanisms. [[1]](diffhunk://#diff-0541a2b7e298ac99ae17f17d35f0e8435e2b998bbefcb7a3cf6db8b511746db9L5-R55) [[2]](diffhunk://#diff-b7d92361932850e67d4b55a7249b2a1b60e327bdf86e6a79b19d98b6fd1008d5R21) [[3]](diffhunk://#diff-b7d92361932850e67d4b55a7249b2a1b60e327bdf86e6a79b19d98b6fd1008d5L47-R48)
- System lifetime is now calculated based on the time since the first NTP sync rather than an `init_time` field, ensuring more accurate uptime reporting. The obsolete `init_time` field is removed from all platforms.

**Core API and Error Handling:**

- Introduced `ciot_iface_get_state()` to query the state of a specific interface by ID, with corresponding header and implementation updates. [[1]](diffhunk://#diff-0541a2b7e298ac99ae17f17d35f0e8435e2b998bbefcb7a3cf6db8b511746db9L5-R55) [[2]](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554R111)
- Improved null pointer checks in MQTT client and interface state retrieval functions, returning default states as appropriate. [[1]](diffhunk://#diff-0541a2b7e298ac99ae17f17d35f0e8435e2b998bbefcb7a3cf6db8b511746db9L5-R55) [[2]](diffhunk://#diff-3c29355ff0857480c7a57573c88ad3ec552a012ff62443b7bcc7fd8537b3efb9L104-R107)

Other notable changes include storage auto-detection improvements, WiFi RSSI read safeguards, event/logging enhancements, and header/dependency updates for consistency.

Release version is incremented to 0.16.0. [[1]](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554L36-R36) [[2]](diffhunk://#diff-64cc7cdde6789dc1c1c4a6f406cd1ff6a6a00027097788e2d52fc27b0d75502eL3-R3)