### PR TITLE
Feat/tcp

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -33,6 +33,11 @@ Configuration improvements:
 
 * Updated the response buffer in the `ciot_http_server` struct to use the configurable maximum response size, and added logic in `ciot_http_server_send_bytes` to truncate responses that exceed the buffer size, logging a warning when truncation occurs. [[1]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692L20-R35) [[2]](diffhunk://#diff-fa8c3f4021f791ed328fcccd28ee915b3f4373dabba5ef1756aca492c007b692R93-R97)
 
+### TCP configuration fixes:
+
+* In `ciot_tcp_set_ip_cfg` for ESP32 (`ciot_tcp.c`), corrected the assignment so that the DNS address (`dns`) is used instead of the netmask (`mask`) when configuring `dns_info`.
+* In `ciot_tcp_set_ip_cfg` for ESP8266 (`ciot_tcp.c`), fixed the DNS configuration to use the DNS address (`dns`) rather than the netmask (`mask`).
+
 ### Version update:
 
-* Bumped the version macro `CIOT_VER` in `include/ciot.h` to `0,19,0,1` to reflect these changes.
+* Bumped the version macro `CIOT_VER` in `include/ciot.h` to `0,19,1,0` to reflect these changes.

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,19,0,1
+#define CIOT_VER 0,19,1,0
 #define CIOT_IFACE_CFG_FILENAME "cfg%d.dat"
 
 #if defined(CIOT_TARGET_WIN) || defined(CIOT_TARGET_LINUX)

--- a/src/esp32/ciot_tcp.c
+++ b/src/esp32/ciot_tcp.c
@@ -234,7 +234,7 @@ static ciot_err_t ciot_tcp_set_ip_cfg(ciot_tcp_t self, ciot_tcp_cfg_t *cfg)
         ip_info.ip.addr = ipaddr_addr(ip);
         ip_info.gw.addr = ipaddr_addr(gateway);
         ip_info.netmask.addr = ipaddr_addr(mask);
-        dns_info.ip.u_addr.ip4.addr = ipaddr_addr(mask);
+        dns_info.ip.u_addr.ip4.addr = ipaddr_addr(dns);
         dns_info.ip.type = IPADDR_TYPE_V4;
 
         CIOT_ERR_RETURN(esp_netif_set_ip_info(netif, &ip_info));

--- a/src/esp8266/ciot_tcp.c
+++ b/src/esp8266/ciot_tcp.c
@@ -204,7 +204,7 @@ static ciot_err_t ciot_tcp_set_ip_cfg(ciot_tcp_t self, ciot_tcp_cfg_t *cfg)
         ip_info.ip.addr = ipaddr_addr(ip);
         ip_info.gw.addr = ipaddr_addr(gateway);
         ip_info.netmask.addr = ipaddr_addr(mask);
-        dns_info.ip.addr = ipaddr_addr(mask);
+        dns_info.ip.addr = ipaddr_addr(dns);
 
         CIOT_ERR_RETURN(tcpip_adapter_set_ip_info(self->netif, &ip_info));
         CIOT_ERR_RETURN(tcpip_adapter_set_dns_info(self->netif, TCPIP_ADAPTER_DNS_MAIN, &dns_info));


### PR DESCRIPTION
This pull request includes a version bump and fixes how DNS configuration is handled in TCP setup functions for both ESP32 and ESP8266 platforms. The main change ensures that the correct DNS address is used instead of mistakenly assigning the netmask value.

Version update:

* Updated the CIOT library version to `0,19,1,0` in `ciot.h`.

TCP configuration fixes:

* In `ciot_tcp_set_ip_cfg` for ESP32 (`ciot_tcp.c`), corrected the assignment so that the DNS address (`dns`) is used instead of the netmask (`mask`) when configuring `dns_info`.
* In `ciot_tcp_set_ip_cfg` for ESP8266 (`ciot_tcp.c`), fixed the DNS configuration to use the DNS address (`dns`) rather than the netmask (`mask`).