### PR TITLE
Feat/mqtt

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -38,6 +38,16 @@ Configuration improvements:
 * In `ciot_tcp_set_ip_cfg` for ESP32 (`ciot_tcp.c`), corrected the assignment so that the DNS address (`dns`) is used instead of the netmask (`mask`) when configuring `dns_info`.
 * In `ciot_tcp_set_ip_cfg` for ESP8266 (`ciot_tcp.c`), fixed the DNS configuration to use the DNS address (`dns`) rather than the netmask (`mask`).
 
+### MQTT client bugfix:
+
+* Updated `ciot_mqtt_client_subtopic_publish` in `ciot_mqtt_client_base.c` to set `base->status.last_msg_time` using `ciot_timer_now()`, ensuring the timestamp is refreshed on each publish.
+
+### WiFi reconnection and event management:
+
+* Added `skip_disconnect_event` flag to the `ciot_wifi` struct to control whether disconnect events are sent during reconnections, preventing redundant events when switching APs (`src/esp32/ciot_wifi.c`).
+* Updated the WiFi station start and stop logic to set TCP state to `DISCONNECTING` and manage the `skip_disconnect_event` flag, ensuring proper event flow and state consistency (`src/esp32/ciot_wifi.c`). [[1]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279R121-R122) [[2]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279R132) [[3]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279R226-R227)
+* Modified the WiFi station event handler to conditionally send the `STOPPED` event based on the `skip_disconnect_event` flag, resetting the flag after use (`src/esp32/ciot_wifi.c`).
+
 ### Version update:
 
-* Bumped the version macro `CIOT_VER` in `include/ciot.h` to `0,19,1,0` to reflect these changes.
+* Changed the `CIOT_VER` macro in `ciot.h` from `0,19,1,0` to `0,19,0,2` to reflect the new version.

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,19,1,0
+#define CIOT_VER 0,19,0,2
 #define CIOT_IFACE_CFG_FILENAME "cfg%d.dat"
 
 #if defined(CIOT_TARGET_WIN) || defined(CIOT_TARGET_LINUX)

--- a/src/common/ciot_mqtt_client_base.c
+++ b/src/common/ciot_mqtt_client_base.c
@@ -68,6 +68,7 @@ ciot_err_t ciot_mqtt_client_subtopic_publish(ciot_mqtt_client_t self, char *subt
     CIOT_ERR_NULL_CHECK(data);
     CIOT_ERR_RETURN(ciot_mqtt_client_set_subtopic(self, subtopic, subtopic_len));
     ciot_mqtt_client_base_t *base = (ciot_mqtt_client_base_t*)self;
+    base->status.last_msg_time = ciot_timer_now();
     return ciot_mqtt_client_publish(self, base->topic_pub, data, size, qos, retain);
 }
 

--- a/src/esp32/ciot_wifi.c
+++ b/src/esp32/ciot_wifi.c
@@ -26,6 +26,7 @@
 struct ciot_wifi
 {
     ciot_wifi_base_t base;
+    bool skip_disconnect_event;     // Skip disconnect event when disconnecting to connect to another AP
     bool reconnecting;
 };
 
@@ -117,6 +118,8 @@ ciot_err_t ciot_wifi_stop(ciot_wifi_t self)
 {
     CIOT_LOGI(TAG, "Stopping WiFi %d", self->base.status.tcp.state);
 
+    ciot_tcp_base_t *tcp = (ciot_tcp_base_t *)self->base.tcp;
+
     self->base.cfg.disabled = true;
 
     wifi_mode_t mode;
@@ -126,6 +129,7 @@ ciot_err_t ciot_wifi_stop(ciot_wifi_t self)
     {
     case CIOT_WIFI_TYPE_STA:
         CIOT_LOGI(TAG, "Stopping station");
+        tcp->status->state = CIOT_TCP_STATE_DISCONNECTING;
         ESP_ERROR_CHECK(esp_wifi_disconnect());
         return CIOT_ERR_OK;
     case CIOT_WIFI_TYPE_AP:
@@ -219,6 +223,8 @@ static ciot_err_t ciot_wifi_start_sta(ciot_wifi_t self, ciot_wifi_cfg_t *cfg)
     if (tcp->status->state == CIOT_TCP_STATE_CONNECTED)
     {
         self->reconnecting = false;
+        self->skip_disconnect_event = true;
+        tcp->status->state = CIOT_TCP_STATE_DISCONNECTING;
         ESP_ERROR_CHECK(esp_wifi_disconnect());
     }
 
@@ -425,7 +431,12 @@ static void ciot_wifi_sta_event_handler(void *handler_args, esp_event_base_t eve
         base->info.ap.authmode = 0;
         memset(base->info.ap.bssid, 0, sizeof(base->info.ap.bssid));
         memset(base->info.ap.ssid, 0, sizeof(base->info.ap.ssid));
-        ciot_iface_send_event_type(&self->base.iface, CIOT_EVENT_TYPE_STOPPED);
+        if(self->skip_disconnect_event == false) {
+            ciot_iface_send_event_type(&base->iface, CIOT_EVENT_TYPE_STOPPED);
+        }
+        else {
+            self->skip_disconnect_event = false;
+        }
         CIOT_LOGI(TAG, "reason: %u", (unsigned int)base->status.disconnect_reason);
         if (base->status.tcp.state == CIOT_TCP_STATE_CONNECTED || self->reconnecting)
         {


### PR DESCRIPTION
This pull request introduces improvements to WiFi reconnection handling and event management, along with a minor version update. The main focus is on preventing unnecessary disconnect events when switching access points, ensuring more accurate state transitions, and updating message timestamps for MQTT client operations.

WiFi reconnection and event management:

* Added `skip_disconnect_event` flag to the `ciot_wifi` struct to control whether disconnect events are sent during reconnections, preventing redundant events when switching APs (`src/esp32/ciot_wifi.c`).
* Updated the WiFi station start and stop logic to set TCP state to `DISCONNECTING` and manage the `skip_disconnect_event` flag, ensuring proper event flow and state consistency (`src/esp32/ciot_wifi.c`). [[1]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279R121-R122) [[2]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279R132) [[3]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279R226-R227)
* Modified the WiFi station event handler to conditionally send the `STOPPED` event based on the `skip_disconnect_event` flag, resetting the flag after use (`src/esp32/ciot_wifi.c`).

MQTT client improvements:

* Updated `ciot_mqtt_client_subtopic_publish` to set the last message timestamp, improving status tracking for published messages (`src/common/ciot_mqtt_client_base.c`).

Version update:

* Changed the `CIOT_VER` macro to `0,19,0,2` for a minor version adjustment (`include/ciot.h`).