### PR TITLE
Feat/mqtt

### DIFF
--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,19,0,2
+#define CIOT_VER 0,19,0,3
 #define CIOT_IFACE_CFG_FILENAME "cfg%d.dat"
 
 #if defined(CIOT_TARGET_WIN) || defined(CIOT_TARGET_LINUX)

--- a/src/esp32/ciot_wifi.c
+++ b/src/esp32/ciot_wifi.c
@@ -26,7 +26,6 @@
 struct ciot_wifi
 {
     ciot_wifi_base_t base;
-    bool skip_disconnect_event;     // Skip disconnect event when disconnecting to connect to another AP
     bool reconnecting;
 };
 
@@ -118,8 +117,6 @@ ciot_err_t ciot_wifi_stop(ciot_wifi_t self)
 {
     CIOT_LOGI(TAG, "Stopping WiFi %d", self->base.status.tcp.state);
 
-    ciot_tcp_base_t *tcp = (ciot_tcp_base_t *)self->base.tcp;
-
     self->base.cfg.disabled = true;
 
     wifi_mode_t mode;
@@ -129,7 +126,6 @@ ciot_err_t ciot_wifi_stop(ciot_wifi_t self)
     {
     case CIOT_WIFI_TYPE_STA:
         CIOT_LOGI(TAG, "Stopping station");
-        tcp->status->state = CIOT_TCP_STATE_DISCONNECTING;
         ESP_ERROR_CHECK(esp_wifi_disconnect());
         return CIOT_ERR_OK;
     case CIOT_WIFI_TYPE_AP:
@@ -223,8 +219,6 @@ static ciot_err_t ciot_wifi_start_sta(ciot_wifi_t self, ciot_wifi_cfg_t *cfg)
     if (tcp->status->state == CIOT_TCP_STATE_CONNECTED)
     {
         self->reconnecting = false;
-        self->skip_disconnect_event = true;
-        tcp->status->state = CIOT_TCP_STATE_DISCONNECTING;
         ESP_ERROR_CHECK(esp_wifi_disconnect());
     }
 
@@ -431,12 +425,7 @@ static void ciot_wifi_sta_event_handler(void *handler_args, esp_event_base_t eve
         base->info.ap.authmode = 0;
         memset(base->info.ap.bssid, 0, sizeof(base->info.ap.bssid));
         memset(base->info.ap.ssid, 0, sizeof(base->info.ap.ssid));
-        if(self->skip_disconnect_event == false) {
-            ciot_iface_send_event_type(&base->iface, CIOT_EVENT_TYPE_STOPPED);
-        }
-        else {
-            self->skip_disconnect_event = false;
-        }
+        ciot_iface_send_event_type(&self->base.iface, CIOT_EVENT_TYPE_STOPPED);
         CIOT_LOGI(TAG, "reason: %u", (unsigned int)base->status.disconnect_reason);
         if (base->status.tcp.state == CIOT_TCP_STATE_CONNECTED || self->reconnecting)
         {


### PR DESCRIPTION
This pull request makes several changes to the WiFi management logic in the ESP32 implementation, mainly simplifying the handling of disconnect events and updating the version number. The most important changes are the removal of the `skip_disconnect_event` mechanism and related logic, which streamlines event handling during WiFi reconnections.

WiFi event handling simplification:

* Removed the `skip_disconnect_event` field from the `ciot_wifi` struct and all related conditional logic, ensuring that disconnect events are always sent and reducing code complexity. [[1]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279L29) [[2]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279L226-L227) [[3]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279L434-R428)
* Removed manual manipulation of TCP state during disconnect operations, relying on standard event flow instead.

Code cleanup:

* Removed unnecessary pointer assignment in the `ciot_wifi_stop` function.

Version update:

* Updated the `CIOT_VER` macro to `0,19,0,3` in `ciot.h` to reflect the new changes.