### PR TITLE
Feat/mbus

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,9 +2,22 @@
 
 ### Changes
 
-**Build and code generation improvements:**
-* Added new targets and variables to `scripts/Makefile` for generating Python and MyPy stubs from `.proto` files using `protoc`, making it easier to regenerate protobuf code as needed.
-* Updated `make/scripts.mk` with a new `mqtt-translator` target and improved path handling for `CIOT_PATH`, supporting more flexible script execution.
+**Modbus Server Enhancements:**
 
-**Cleanup of generated files:**
-* Removed the generated protobuf Python files `scripts/ciot/proto/v1/ble_pb2.py` and `scripts/ciot/proto/v1/ble_adv_pb2.py` from version control, encouraging regeneration via the new Makefile targets rather than tracking generated code. [[1]](diffhunk://#diff-7bdadad2b5341ca49c2a3da5e39a89803796a4d5b87169ceb7f4ef8c17f1c49dL1-L344) [[2]](diffhunk://#diff-b6419d15abc96580c8db4c5575da352136e088111a4f222e54e35a88d9e5ea64L1-L303)
+* Added new status fields to `ciot_mbus_server_status_t` to track error codes, timestamps for last pool, update, and request, as well as request count. These fields are now updated in the server logic to provide more detailed runtime information. [[1]](diffhunk://#diff-2879311ce531e391c9c16a7e6a20f966629ea88f91d30ecbf7f0844f3ed63f0aR54-R58) [[2]](diffhunk://#diff-2879311ce531e391c9c16a7e6a20f966629ea88f91d30ecbf7f0844f3ed63f0aL101-R115) [[3]](diffhunk://#diff-2879311ce531e391c9c16a7e6a20f966629ea88f91d30ecbf7f0844f3ed63f0aR127-R131) [[4]](diffhunk://#diff-2879311ce531e391c9c16a7e6a20f966629ea88f91d30ecbf7f0844f3ed63f0aL154-R171) [[5]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L116-R119) [[6]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909R133) [[7]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L169-R176) [[8]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L178-R196) [[9]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L195-R216) [[10]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L212-R236)
+
+* Improved error handling in server read/write functions by returning standard NMBS error codes instead of custom enum values. [[1]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L160-R164) [[2]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L178-R196) [[3]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L195-R216) [[4]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L212-R236)
+
+**Modbus Client and Server Error Type Unification:**
+
+* Changed MBUS client and server error fields to use the unified `ciot_err_t` type, and removed the custom `ciot_mbus_error_t` enum from the protocol definitions. [[1]](diffhunk://#diff-6bf44a776dd28cd8ec06193fb80a558c71c3f9214b21e0596abb4a124d546fd1L54-R55) [[2]](diffhunk://#diff-6bf44a776dd28cd8ec06193fb80a558c71c3f9214b21e0596abb4a124d546fd1L94-R95) [[3]](diffhunk://#diff-6bf44a776dd28cd8ec06193fb80a558c71c3f9214b21e0596abb4a124d546fd1L104-R112) [[4]](diffhunk://#diff-cf8eec702cf8be674eacc67764003b9b6f78cabc7edf27711fce43fdd3974a2cL13-L24) [[5]](diffhunk://#diff-cf8eec702cf8be674eacc67764003b9b6f78cabc7edf27711fce43fdd3974a2cL56-L67) [[6]](diffhunk://#diff-2879311ce531e391c9c16a7e6a20f966629ea88f91d30ecbf7f0844f3ed63f0aR98)
+
+* Updated protocol buffer includes to add `errors.pb.h` where needed to support the new error type. [[1]](diffhunk://#diff-6bf44a776dd28cd8ec06193fb80a558c71c3f9214b21e0596abb4a124d546fd1R9) [[2]](diffhunk://#diff-2879311ce531e391c9c16a7e6a20f966629ea88f91d30ecbf7f0844f3ed63f0aR7)
+
+**UART Start Logic Improvements:**
+
+* Refined the UART start logic in `ciot_uart_start` to prevent changing the UART number without stopping the interface first, and improved logging and error returns for invalid state transitions. [[1]](diffhunk://#diff-c8a5a36ea012ff34598ad0ee6f74aaf1c434a0083acbc5a0c877c116db5bcceaL79-L100) [[2]](diffhunk://#diff-c8a5a36ea012ff34598ad0ee6f74aaf1c434a0083acbc5a0c877c116db5bcceaL113-R113) [[3]](diffhunk://#diff-c8a5a36ea012ff34598ad0ee6f74aaf1c434a0083acbc5a0c877c116db5bcceaR123-R125)
+
+**Build Script Update:**
+
+* Updated the `make/scripts.mk` script to use new environment variable names and the correct path for the MQTT translator script.

--- a/make/scripts.mk
+++ b/make/scripts.mk
@@ -1,5 +1,5 @@
 CIOT_PATH := $(subst \,/,$(CIOT_PATH))
 
 mqtt-translator:
-	@echo "Running MQTT translator with host=$(host), port=$(port), topic=$(topic), username=$(username), password=$(password)"
-	@python $(CIOT_PATH)/scripts/mqtt_translator.py --host $(host) --port $(port) --topic $(topic) --username $(username) --password $(password) --topic $(topic)
+	@echo "Running MQTT translator with host=$(MQTT_HOST), port=$(MQTT_PORT), topic=$(MQTT_TOPIC), username=$(MQTT_USERNAME), password=$(MQTT_PASSWORD)"
+	@python $(CIOT_PATH)/ciot_c/scripts/mqtt_translator.py --host $(MQTT_HOST) --port $(MQTT_PORT) --topic $(MQTT_TOPIC) --username $(MQTT_USERNAME) --password $(MQTT_PASSWORD)

--- a/src/common/ciot_mbus_server.c
+++ b/src/common/ciot_mbus_server.c
@@ -115,7 +115,7 @@ ciot_err_t ciot_mbus_server_task(ciot_mbus_server_t self)
     {
         nmbs_error err = nmbs_server_poll(&self->nmbs);
         self->base.status.error = ciot_mbus_get_error(err);
-        self->base.status.last_pool = ciot_timer_now();
+        self->base.status.last_poll = ciot_timer_now();
         return self->base.status.error;
     }
     return CIOT_ERR_OK;

--- a/src/common/ciot_mbus_server.c
+++ b/src/common/ciot_mbus_server.c
@@ -14,6 +14,7 @@
 #if CIOT_CONFIG_FEATURE_MBUS_SERVER == 1
 
 #include "ciot_mbus_server.h"
+#include "ciot_timer.h"
 #include "ciot_uart.h"
 #include <stdlib.h>
 
@@ -113,7 +114,9 @@ ciot_err_t ciot_mbus_server_task(ciot_mbus_server_t self)
     if (self->base.status.state == CIOT_MBUS_SERVER_STATE_STARTED && self->base.conn->state == CIOT_IFACE_STATE_STARTED)
     {
         nmbs_error err = nmbs_server_poll(&self->nmbs);
-        return err != NMBS_ERROR_NONE ? ciot_mbus_get_error(err) : CIOT_ERR_OK;
+        self->base.status.error = ciot_mbus_get_error(err);
+        self->base.status.last_pool = ciot_timer_now();
+        return self->base.status.error;
     }
     return CIOT_ERR_OK;
 }
@@ -127,6 +130,7 @@ ciot_err_t ciot_mbus_server_set_reg(ciot_mbus_server_t self, uint16_t addr, void
 {
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_UINDEX_CHECK(addr, self->base.data.regs.count - size);
+    self->base.status.last_update = ciot_timer_now();
     memcpy(&self->base.data.regs.values[addr], data, size);
     return CIOT_ERR_OK;
 }
@@ -157,7 +161,7 @@ static nmbs_error ciot_mbus_server_read_coils(uint16_t address, uint16_t quantit
 
     if (address + quantity > self->base.data.coils.count)
     {
-        return (nmbs_error)CIOT_ERR_MBUS_EXCEPTION_ILLEGAL_DATA_ADDR;
+        return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS;
     }
 
     for (size_t i = 0; i < quantity; i++)
@@ -166,7 +170,10 @@ static nmbs_error ciot_mbus_server_read_coils(uint16_t address, uint16_t quantit
         nmbs_bitfield_write(coils_out, i, value);
     }
 
-    return (nmbs_error)CIOT_ERR_OK;
+    self->base.status.last_request = ciot_timer_now();
+    self->base.status.request_count++;
+
+    return NMBS_ERROR_NONE;
 }
 
 static nmbs_error ciot_mbus_server_write_multiple_coils(uint16_t address, uint16_t quantity, const nmbs_bitfield coils, uint8_t unit_id, void *arg)
@@ -175,7 +182,7 @@ static nmbs_error ciot_mbus_server_write_multiple_coils(uint16_t address, uint16
 
     if (address + quantity > self->base.data.coils.count)
     {
-        return (nmbs_error)CIOT_ERR_MBUS_EXCEPTION_ILLEGAL_DATA_ADDR;
+        return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS;
     }
 
     for (int i = 0; i < quantity; i++)
@@ -183,7 +190,10 @@ static nmbs_error ciot_mbus_server_write_multiple_coils(uint16_t address, uint16
         nmbs_bitfield_write(self->base.data.coils.values, address + i, nmbs_bitfield_read(coils, i));
     }
 
-    return (nmbs_error)CIOT_ERR_OK;
+    self->base.status.last_request = ciot_timer_now();
+    self->base.status.request_count++;
+
+    return NMBS_ERROR_NONE;
 }
 
 static nmbs_error ciot_mbus_server_read_holding_registers(uint16_t address, uint16_t quantity, uint16_t *registers_out, uint8_t unit_id, void *arg)
@@ -192,7 +202,7 @@ static nmbs_error ciot_mbus_server_read_holding_registers(uint16_t address, uint
 
     if (address + quantity > self->base.data.regs.count)
     {
-        return (nmbs_error)CIOT_ERR_MBUS_EXCEPTION_ILLEGAL_DATA_ADDR;
+        return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS;
     }
 
     for (size_t i = 0; i < quantity; i++)
@@ -200,7 +210,10 @@ static nmbs_error ciot_mbus_server_read_holding_registers(uint16_t address, uint
         registers_out[i] = self->base.data.regs.values[address + i];
     }
 
-    return (nmbs_error)CIOT_ERR_OK;
+    self->base.status.last_request = ciot_timer_now();
+    self->base.status.request_count++;
+
+    return NMBS_ERROR_NONE;
 }
 
 static nmbs_error ciot_mbus_server_write_multiple_registers(uint16_t address, uint16_t quantity, const uint16_t *registers, uint8_t unit_id, void *arg)
@@ -209,7 +222,7 @@ static nmbs_error ciot_mbus_server_write_multiple_registers(uint16_t address, ui
 
     if (address + quantity > self->base.data.regs.count)
     {
-        return (nmbs_error)CIOT_ERR_MBUS_EXCEPTION_ILLEGAL_DATA_ADDR;
+        return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS;
     }
 
     for (size_t i = 0; i < quantity; i++)
@@ -217,7 +230,10 @@ static nmbs_error ciot_mbus_server_write_multiple_registers(uint16_t address, ui
         self->base.data.regs.values[address + i] = registers[i];
     }
 
-    return (nmbs_error)CIOT_ERR_OK;
+    self->base.status.last_request = ciot_timer_now();
+    self->base.status.request_count++;
+
+    return NMBS_ERROR_NONE;
 }
 
 #endif // CIOT_CONFIG_FEATURE_MBUS_SERVER == 1

--- a/src/esp32/ciot_uart.c
+++ b/src/esp32/ciot_uart.c
@@ -75,28 +75,21 @@ ciot_err_t ciot_uart_start(ciot_uart_t self, ciot_uart_cfg_t *cfg)
 
     ciot_uart_base_t *base = &self->base;
 
-    if(base->status.state == CIOT_UART_STATE_STARTED &&
-       base->cfg.num == cfg->num)
+    if (base->status.state == CIOT_UART_STATE_STARTED &&
+        base->cfg.num != cfg->num)
     {
-        CIOT_LOGW(TAG, "UART %d already started", (int)base->cfg.num);
-        return CIOT_ERR_OK;
+        CIOT_LOGW(TAG, "Can't change UART number from %d to %d. Stop UART first", (int)base->cfg.num, (int)cfg->num);
+        return CIOT_ERR_INVALID_STATE;
     }
 
     CIOT_LOGI(TAG, "num: %d", (int)cfg->num);
 
-    if(base->status.state == CIOT_UART_STATE_STARTED)
-    {
-        CIOT_LOGW(TAG, "UART already started");
-        return CIOT_ERR_OK;
-    }
-
-    if(cfg->has_gpio == false)
+    if (cfg->has_gpio == false)
     {
         cfg->has_gpio = base->cfg.has_gpio;
         cfg->gpio = base->cfg.gpio;
     }
     base->cfg = *cfg;
-
 
     int num = base->cfg.num;
     const uart_config_t uart_cfg = {
@@ -110,19 +103,26 @@ ciot_err_t ciot_uart_start(ciot_uart_t self, ciot_uart_cfg_t *cfg)
 
     ESP_ERROR_CHECK(uart_param_config(num, &uart_cfg));
     ESP_ERROR_CHECK(uart_set_pin(num, base->cfg.gpio.tx, base->cfg.gpio.rx, base->cfg.gpio.rts, base->cfg.gpio.cts));
-    ESP_ERROR_CHECK(uart_driver_install(num, CIOT_CONFIG_UART_RX_BUF_SIZE, CIOT_CONFIG_UART_TX_BUF_SIZE, CIOT_CONFIG_UART_QUEUE_SIZE, &self->queue, 0));
-    ESP_ERROR_CHECK(uart_set_mode(num, base->cfg.mode));
 
-    if(base->iface.decoder)
+    if (base->status.state == CIOT_UART_STATE_STARTED)
     {
-        if (num == 0)
-            xTaskCreatePinnedToCore(ciot_uart0_task, "ciot_uart0_task", CIOT_CONFIG_UART_TASK_SIZE, self, CIOT_CONFIG_UART_TASK_PRIO, &self->task, CIOT_CONFIG_UART_TASK_CORE);
-        if (num == 1)
-            xTaskCreatePinnedToCore(ciot_uart1_task, "ciot_uart1_task", CIOT_CONFIG_UART_TASK_SIZE, self, CIOT_CONFIG_UART_TASK_PRIO, &self->task, CIOT_CONFIG_UART_TASK_CORE);
-        if (num == 2)
-            xTaskCreatePinnedToCore(ciot_uart2_task, "ciot_uart2_task", CIOT_CONFIG_UART_TASK_SIZE, self, CIOT_CONFIG_UART_TASK_PRIO, &self->task, CIOT_CONFIG_UART_TASK_CORE);
+        CIOT_LOGI(TAG, "UART already started");
+    }
+    else
+    {
+        ESP_ERROR_CHECK(uart_driver_install(num, CIOT_CONFIG_UART_RX_BUF_SIZE, CIOT_CONFIG_UART_TX_BUF_SIZE, CIOT_CONFIG_UART_QUEUE_SIZE, &self->queue, 0));
+        if (base->iface.decoder)
+        {
+            if (num == 0)
+                xTaskCreatePinnedToCore(ciot_uart0_task, "ciot_uart0_task", CIOT_CONFIG_UART_TASK_SIZE, self, CIOT_CONFIG_UART_TASK_PRIO, &self->task, CIOT_CONFIG_UART_TASK_CORE);
+            if (num == 1)
+                xTaskCreatePinnedToCore(ciot_uart1_task, "ciot_uart1_task", CIOT_CONFIG_UART_TASK_SIZE, self, CIOT_CONFIG_UART_TASK_PRIO, &self->task, CIOT_CONFIG_UART_TASK_CORE);
+            if (num == 2)
+                xTaskCreatePinnedToCore(ciot_uart2_task, "ciot_uart2_task", CIOT_CONFIG_UART_TASK_SIZE, self, CIOT_CONFIG_UART_TASK_PRIO, &self->task, CIOT_CONFIG_UART_TASK_CORE);
+        }
     }
 
+    ESP_ERROR_CHECK(uart_set_mode(num, base->cfg.mode));
     base->status.state = CIOT_UART_STATE_STARTED;
     ciot_iface_send_event_type(&base->iface, CIOT_EVENT_TYPE_STARTED);
 
@@ -133,7 +133,7 @@ ciot_err_t ciot_uart_stop(ciot_uart_t self)
 {
     CIOT_ERR_NULL_CHECK(self);
     CIOT_LOGI(TAG, "Stopping UART %d", (int)self->base.cfg.num);
-    if(self->base.status.state == CIOT_UART_STATE_CLOSED)
+    if (self->base.status.state == CIOT_UART_STATE_CLOSED)
     {
         CIOT_LOGW(TAG, "UART %d already stopped", (int)self->base.cfg.num);
         return CIOT_ERR_OK;

--- a/src/protos/ciot/proto/v2/mbus.pb.c
+++ b/src/protos/ciot/proto/v2/mbus.pb.c
@@ -12,5 +12,3 @@ PB_BIND(CIOT_MBUS_FUNCTION_REQ, ciot_mbus_function_req_t, AUTO)
 
 
 
-
-

--- a/src/protos/ciot/proto/v2/mbus.pb.h
+++ b/src/protos/ciot/proto/v2/mbus.pb.h
@@ -29,7 +29,7 @@ typedef struct ciot_mbus_function_req {
     ciot_mbus_func_code_t code; /* Modbus function code */
     uint32_t address; /* Register/coil start address */
     pb_size_t data_count;
-    uint32_t data[32]; /* Optional written values. */
+    uint32_t data[32]; /* Optional written/read values. */
     uint32_t read_count; /* Optional values count to read */
     uint32_t max_attempts; /* Max attempts */
     uint32_t error; /* Error code */

--- a/src/protos/ciot/proto/v2/mbus.pb.h
+++ b/src/protos/ciot/proto/v2/mbus.pb.h
@@ -10,18 +10,6 @@
 #endif
 
 /* Enum definitions */
-/* Enum representing Modbus client error codes. */
-typedef enum ciot_mbus_error {
-    CIOT_MBUS_ERROR_NONE = 0, /* No error */
-    CIOT_MBUS_ERROR_REG_ADDR = 1, /* Invalid register address */
-    CIOT_MBUS_ERROR_ARG = 2, /* Invalid argument */
-    CIOT_MBUS_ERROR_PORT_LAYER = 3, /* Port layer error */
-    CIOT_MBUS_ERROR_NO_RESOURCE = 4, /* No resource error */
-    CIOT_MBUS_ERROR_IO = 5, /* I/O error */
-    CIOT_MBUS_ERROR_STATE = 6, /* Protocol stack invalid state error */
-    CIOT_MBUS_ERROR_TIMEOUT = 7 /* Timeout error */
-} ciot_mbus_error_t;
-
 /* Enum representing Modbus function codes */
 typedef enum ciot_mbus_func_code {
     CIOT_MBUS_FUNC_CODE_NONE = 0, /* No function */
@@ -53,18 +41,6 @@ extern "C" {
 #endif
 
 /* Helper constants for enums */
-#define _CIOT_MBUS_ERROR_MIN CIOT_MBUS_ERROR_NONE
-#define _CIOT_MBUS_ERROR_MAX CIOT_MBUS_ERROR_TIMEOUT
-#define _CIOT_MBUS_ERROR_ARRAYSIZE ((ciot_mbus_error_t)(CIOT_MBUS_ERROR_TIMEOUT+1))
-#define CIOT_MBUS_ERROR_MBUS_ERROR_NONE CIOT_MBUS_ERROR_NONE
-#define CIOT_MBUS_ERROR_MBUS_ERROR_REG_ADDR CIOT_MBUS_ERROR_REG_ADDR
-#define CIOT_MBUS_ERROR_MBUS_ERROR_ARG CIOT_MBUS_ERROR_ARG
-#define CIOT_MBUS_ERROR_MBUS_ERROR_PORT_LAYER CIOT_MBUS_ERROR_PORT_LAYER
-#define CIOT_MBUS_ERROR_MBUS_ERROR_NO_RESOURCE CIOT_MBUS_ERROR_NO_RESOURCE
-#define CIOT_MBUS_ERROR_MBUS_ERROR_IO CIOT_MBUS_ERROR_IO
-#define CIOT_MBUS_ERROR_MBUS_ERROR_STATE CIOT_MBUS_ERROR_STATE
-#define CIOT_MBUS_ERROR_MBUS_ERROR_TIMEOUT CIOT_MBUS_ERROR_TIMEOUT
-
 #define _CIOT_MBUS_FUNC_CODE_MIN CIOT_MBUS_FUNC_CODE_NONE
 #define _CIOT_MBUS_FUNC_CODE_MAX CIOT_MBUS_FUNC_CODE_WRITE_MULTIPLE_HR
 #define _CIOT_MBUS_FUNC_CODE_ARRAYSIZE ((ciot_mbus_func_code_t)(CIOT_MBUS_FUNC_CODE_WRITE_MULTIPLE_HR+1))

--- a/src/protos/ciot/proto/v2/mbus_client.pb.h
+++ b/src/protos/ciot/proto/v2/mbus_client.pb.h
@@ -6,6 +6,7 @@
 #include <pb.h>
 #include "ciot/proto/v2/mbus.pb.h"
 #include "ciot/proto/v2/uart.pb.h"
+#include "ciot/proto/v2/errors.pb.h"
 
 #if PB_PROTO_HEADER_VERSION != 40
 #error Regenerate this file with the current version of nanopb generator.
@@ -51,7 +52,7 @@ typedef struct ciot_mbus_client_cfg {
 /* Message representing Modbus client status. */
 typedef struct ciot_mbus_client_status {
     ciot_mbus_client_state_t state; /* State of the Modbus client. */
-    ciot_mbus_error_t error; /* Modbus client error code. */
+    ciot_err_t error; /* Modbus client error code. */
 } ciot_mbus_client_status_t;
 
 /* Message representing an Modbus client request. */
@@ -91,7 +92,7 @@ extern "C" {
 
 
 #define ciot_mbus_client_status_t_state_ENUMTYPE ciot_mbus_client_state_t
-#define ciot_mbus_client_status_t_error_ENUMTYPE ciot_mbus_error_t
+#define ciot_mbus_client_status_t_error_ENUMTYPE ciot_err_t
 
 
 
@@ -101,14 +102,14 @@ extern "C" {
 #define CIOT_MBUS_CLIENT_RTU_CFG_INIT_DEFAULT    {0, false, CIOT_UART_CFG_INIT_DEFAULT}
 #define CIOT_MBUS_CLIENT_TCP_CFG_INIT_DEFAULT    {{{NULL}, NULL}, 0}
 #define CIOT_MBUS_CLIENT_CFG_INIT_DEFAULT        {0, {CIOT_MBUS_CLIENT_RTU_CFG_INIT_DEFAULT}, 0}
-#define CIOT_MBUS_CLIENT_STATUS_INIT_DEFAULT     {_CIOT_MBUS_CLIENT_STATE_MIN, _CIOT_MBUS_ERROR_MIN}
+#define CIOT_MBUS_CLIENT_STATUS_INIT_DEFAULT     {_CIOT_MBUS_CLIENT_STATE_MIN, _CIOT_ERR_MIN}
 #define CIOT_MBUS_CLIENT_REQ_INIT_DEFAULT        {0, {CIOT_MBUS_FUNCTION_REQ_INIT_DEFAULT}}
 #define CIOT_MBUS_CLIENT_DATA_INIT_DEFAULT       {0, {CIOT_MBUS_CLIENT_STOP_INIT_DEFAULT}}
 #define CIOT_MBUS_CLIENT_STOP_INIT_ZERO          {0}
 #define CIOT_MBUS_CLIENT_RTU_CFG_INIT_ZERO       {0, false, CIOT_UART_CFG_INIT_ZERO}
 #define CIOT_MBUS_CLIENT_TCP_CFG_INIT_ZERO       {{{NULL}, NULL}, 0}
 #define CIOT_MBUS_CLIENT_CFG_INIT_ZERO           {0, {CIOT_MBUS_CLIENT_RTU_CFG_INIT_ZERO}, 0}
-#define CIOT_MBUS_CLIENT_STATUS_INIT_ZERO        {_CIOT_MBUS_CLIENT_STATE_MIN, _CIOT_MBUS_ERROR_MIN}
+#define CIOT_MBUS_CLIENT_STATUS_INIT_ZERO        {_CIOT_MBUS_CLIENT_STATE_MIN, _CIOT_ERR_MIN}
 #define CIOT_MBUS_CLIENT_REQ_INIT_ZERO           {0, {CIOT_MBUS_FUNCTION_REQ_INIT_ZERO}}
 #define CIOT_MBUS_CLIENT_DATA_INIT_ZERO          {0, {CIOT_MBUS_CLIENT_STOP_INIT_ZERO}}
 

--- a/src/protos/ciot/proto/v2/mbus_server.pb.h
+++ b/src/protos/ciot/proto/v2/mbus_server.pb.h
@@ -4,6 +4,7 @@
 #ifndef PB_CIOT_CIOT_PROTO_V2_MBUS_SERVER_PB_H_INCLUDED
 #define PB_CIOT_CIOT_PROTO_V2_MBUS_SERVER_PB_H_INCLUDED
 #include <pb.h>
+#include "ciot/proto/v2/errors.pb.h"
 #include "ciot/proto/v2/mbus.pb.h"
 #include "ciot/proto/v2/uart.pb.h"
 
@@ -50,6 +51,11 @@ typedef struct ciot_mbus_server_cfg {
 /* Message representing Modbus server status. */
 typedef struct ciot_mbus_server_status {
     ciot_mbus_server_state_t state; /* State of the Modbus server. */
+    ciot_err_t error; /* Last error code of the Modbus server. */
+    uint64_t last_pool; /* Timestamp of the last pool in milliseconds since epoch. */
+    uint64_t last_update; /* Timestamp of the last update in milliseconds since epoch. */
+    uint64_t last_request; /* Timestamp of the last request in milliseconds since epoch. */
+    uint32_t request_count; /* Total number of requests handled by the Modbus server. */
 } ciot_mbus_server_status_t;
 
 /* Message representing an Modbus server request. */
@@ -89,6 +95,7 @@ extern "C" {
 
 
 #define ciot_mbus_server_status_t_state_ENUMTYPE ciot_mbus_server_state_t
+#define ciot_mbus_server_status_t_error_ENUMTYPE ciot_err_t
 
 
 
@@ -98,14 +105,14 @@ extern "C" {
 #define CIOT_MBUS_SERVER_RTU_CFG_INIT_DEFAULT    {0, false, CIOT_UART_CFG_INIT_DEFAULT}
 #define CIOT_MBUS_SERVER_TCP_CFG_INIT_DEFAULT    {0, 0}
 #define CIOT_MBUS_SERVER_CFG_INIT_DEFAULT        {0, {CIOT_MBUS_SERVER_RTU_CFG_INIT_DEFAULT}}
-#define CIOT_MBUS_SERVER_STATUS_INIT_DEFAULT     {_CIOT_MBUS_SERVER_STATE_MIN}
+#define CIOT_MBUS_SERVER_STATUS_INIT_DEFAULT     {_CIOT_MBUS_SERVER_STATE_MIN, _CIOT_ERR_MIN, 0, 0, 0, 0}
 #define CIOT_MBUS_SERVER_REQ_INIT_DEFAULT        {0, {CIOT_MBUS_FUNCTION_REQ_INIT_DEFAULT}}
 #define CIOT_MBUS_SERVER_DATA_INIT_DEFAULT       {0, {CIOT_MBUS_SERVER_STOP_INIT_DEFAULT}}
 #define CIOT_MBUS_SERVER_STOP_INIT_ZERO          {0}
 #define CIOT_MBUS_SERVER_RTU_CFG_INIT_ZERO       {0, false, CIOT_UART_CFG_INIT_ZERO}
 #define CIOT_MBUS_SERVER_TCP_CFG_INIT_ZERO       {0, 0}
 #define CIOT_MBUS_SERVER_CFG_INIT_ZERO           {0, {CIOT_MBUS_SERVER_RTU_CFG_INIT_ZERO}}
-#define CIOT_MBUS_SERVER_STATUS_INIT_ZERO        {_CIOT_MBUS_SERVER_STATE_MIN}
+#define CIOT_MBUS_SERVER_STATUS_INIT_ZERO        {_CIOT_MBUS_SERVER_STATE_MIN, _CIOT_ERR_MIN, 0, 0, 0, 0}
 #define CIOT_MBUS_SERVER_REQ_INIT_ZERO           {0, {CIOT_MBUS_FUNCTION_REQ_INIT_ZERO}}
 #define CIOT_MBUS_SERVER_DATA_INIT_ZERO          {0, {CIOT_MBUS_SERVER_STOP_INIT_ZERO}}
 
@@ -117,6 +124,11 @@ extern "C" {
 #define CIOT_MBUS_SERVER_CFG_RTU_TAG             1
 #define CIOT_MBUS_SERVER_CFG_TCP_TAG             2
 #define CIOT_MBUS_SERVER_STATUS_STATE_TAG        1
+#define CIOT_MBUS_SERVER_STATUS_ERROR_TAG        2
+#define CIOT_MBUS_SERVER_STATUS_LAST_POOL_TAG    3
+#define CIOT_MBUS_SERVER_STATUS_LAST_UPDATE_TAG  4
+#define CIOT_MBUS_SERVER_STATUS_LAST_REQUEST_TAG 5
+#define CIOT_MBUS_SERVER_STATUS_REQUEST_COUNT_TAG 6
 #define CIOT_MBUS_SERVER_REQ_FUNCTION_TAG        1
 #define CIOT_MBUS_SERVER_DATA_STOP_TAG           1
 #define CIOT_MBUS_SERVER_DATA_CONFIG_TAG         2
@@ -151,7 +163,12 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (type,tcp,tcp),    2)
 #define ciot_mbus_server_cfg_t_type_tcp_MSGTYPE ciot_mbus_server_tcp_cfg_t
 
 #define CIOT_MBUS_SERVER_STATUS_FIELDLIST(X, a) \
-X(a, STATIC,   SINGULAR, UENUM,    state,             1)
+X(a, STATIC,   SINGULAR, UENUM,    state,             1) \
+X(a, STATIC,   SINGULAR, UENUM,    error,             2) \
+X(a, STATIC,   SINGULAR, UINT64,   last_pool,         3) \
+X(a, STATIC,   SINGULAR, UINT64,   last_update,       4) \
+X(a, STATIC,   SINGULAR, UINT64,   last_request,      5) \
+X(a, STATIC,   SINGULAR, UINT32,   request_count,     6)
 #define CIOT_MBUS_SERVER_STATUS_CALLBACK NULL
 #define CIOT_MBUS_SERVER_STATUS_DEFAULT NULL
 
@@ -196,7 +213,7 @@ extern const pb_msgdesc_t ciot_mbus_server_data_t_msg;
 #define CIOT_MBUS_SERVER_DATA_SIZE               224
 #define CIOT_MBUS_SERVER_REQ_SIZE                221
 #define CIOT_MBUS_SERVER_RTU_CFG_SIZE            74
-#define CIOT_MBUS_SERVER_STATUS_SIZE             2
+#define CIOT_MBUS_SERVER_STATUS_SIZE             43
 #define CIOT_MBUS_SERVER_STOP_SIZE               0
 #define CIOT_MBUS_SERVER_TCP_CFG_SIZE            12
 

--- a/src/protos/ciot/proto/v2/mbus_server.pb.h
+++ b/src/protos/ciot/proto/v2/mbus_server.pb.h
@@ -52,9 +52,9 @@ typedef struct ciot_mbus_server_cfg {
 typedef struct ciot_mbus_server_status {
     ciot_mbus_server_state_t state; /* State of the Modbus server. */
     ciot_err_t error; /* Last error code of the Modbus server. */
-    uint64_t last_pool; /* Timestamp of the last pool in milliseconds since epoch. */
-    uint64_t last_update; /* Timestamp of the last update in milliseconds since epoch. */
-    uint64_t last_request; /* Timestamp of the last request in milliseconds since epoch. */
+    uint64_t last_pool; /* Timestamp of the last pool in seconds since epoch. */
+    uint64_t last_update; /* Timestamp of the last update in seconds since epoch. */
+    uint64_t last_request; /* Timestamp of the last request in seconds since epoch. */
     uint32_t request_count; /* Total number of requests handled by the Modbus server. */
 } ciot_mbus_server_status_t;
 

--- a/src/protos/ciot/proto/v2/mbus_server.pb.h
+++ b/src/protos/ciot/proto/v2/mbus_server.pb.h
@@ -52,7 +52,7 @@ typedef struct ciot_mbus_server_cfg {
 typedef struct ciot_mbus_server_status {
     ciot_mbus_server_state_t state; /* State of the Modbus server. */
     ciot_err_t error; /* Last error code of the Modbus server. */
-    uint64_t last_pool; /* Timestamp of the last pool in seconds since epoch. */
+    uint64_t last_poll; /* Timestamp of the last poll in seconds since epoch. */
     uint64_t last_update; /* Timestamp of the last update in seconds since epoch. */
     uint64_t last_request; /* Timestamp of the last request in seconds since epoch. */
     uint32_t request_count; /* Total number of requests handled by the Modbus server. */
@@ -125,7 +125,7 @@ extern "C" {
 #define CIOT_MBUS_SERVER_CFG_TCP_TAG             2
 #define CIOT_MBUS_SERVER_STATUS_STATE_TAG        1
 #define CIOT_MBUS_SERVER_STATUS_ERROR_TAG        2
-#define CIOT_MBUS_SERVER_STATUS_LAST_POOL_TAG    3
+#define CIOT_MBUS_SERVER_STATUS_LAST_POLL_TAG    3
 #define CIOT_MBUS_SERVER_STATUS_LAST_UPDATE_TAG  4
 #define CIOT_MBUS_SERVER_STATUS_LAST_REQUEST_TAG 5
 #define CIOT_MBUS_SERVER_STATUS_REQUEST_COUNT_TAG 6
@@ -165,7 +165,7 @@ X(a, STATIC,   ONEOF,    MESSAGE,  (type,tcp,tcp),    2)
 #define CIOT_MBUS_SERVER_STATUS_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, UENUM,    state,             1) \
 X(a, STATIC,   SINGULAR, UENUM,    error,             2) \
-X(a, STATIC,   SINGULAR, UINT64,   last_pool,         3) \
+X(a, STATIC,   SINGULAR, UINT64,   last_poll,         3) \
 X(a, STATIC,   SINGULAR, UINT64,   last_update,       4) \
 X(a, STATIC,   SINGULAR, UINT64,   last_request,      5) \
 X(a, STATIC,   SINGULAR, UINT32,   request_count,     6)


### PR DESCRIPTION
This pull request introduces several important updates to the Modbus (MBUS) server and client code, focusing on improving error handling, status reporting, and code consistency. The changes add new status fields to the MBUS server, unify error types across MBUS components, and update the UART start logic for better state management.

**Modbus Server Enhancements:**

* Added new status fields to `ciot_mbus_server_status_t` to track error codes, timestamps for last pool, update, and request, as well as request count. These fields are now updated in the server logic to provide more detailed runtime information. [[1]](diffhunk://#diff-2879311ce531e391c9c16a7e6a20f966629ea88f91d30ecbf7f0844f3ed63f0aR54-R58) [[2]](diffhunk://#diff-2879311ce531e391c9c16a7e6a20f966629ea88f91d30ecbf7f0844f3ed63f0aL101-R115) [[3]](diffhunk://#diff-2879311ce531e391c9c16a7e6a20f966629ea88f91d30ecbf7f0844f3ed63f0aR127-R131) [[4]](diffhunk://#diff-2879311ce531e391c9c16a7e6a20f966629ea88f91d30ecbf7f0844f3ed63f0aL154-R171) [[5]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L116-R119) [[6]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909R133) [[7]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L169-R176) [[8]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L178-R196) [[9]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L195-R216) [[10]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L212-R236)

* Improved error handling in server read/write functions by returning standard NMBS error codes instead of custom enum values. [[1]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L160-R164) [[2]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L178-R196) [[3]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L195-R216) [[4]](diffhunk://#diff-7692b439c4b1916834495a096ae6cdb3cbb16652175e7d0b1240cd81dcd8a909L212-R236)

**Modbus Client and Server Error Type Unification:**

* Changed MBUS client and server error fields to use the unified `ciot_err_t` type, and removed the custom `ciot_mbus_error_t` enum from the protocol definitions. [[1]](diffhunk://#diff-6bf44a776dd28cd8ec06193fb80a558c71c3f9214b21e0596abb4a124d546fd1L54-R55) [[2]](diffhunk://#diff-6bf44a776dd28cd8ec06193fb80a558c71c3f9214b21e0596abb4a124d546fd1L94-R95) [[3]](diffhunk://#diff-6bf44a776dd28cd8ec06193fb80a558c71c3f9214b21e0596abb4a124d546fd1L104-R112) [[4]](diffhunk://#diff-cf8eec702cf8be674eacc67764003b9b6f78cabc7edf27711fce43fdd3974a2cL13-L24) [[5]](diffhunk://#diff-cf8eec702cf8be674eacc67764003b9b6f78cabc7edf27711fce43fdd3974a2cL56-L67) [[6]](diffhunk://#diff-2879311ce531e391c9c16a7e6a20f966629ea88f91d30ecbf7f0844f3ed63f0aR98)

* Updated protocol buffer includes to add `errors.pb.h` where needed to support the new error type. [[1]](diffhunk://#diff-6bf44a776dd28cd8ec06193fb80a558c71c3f9214b21e0596abb4a124d546fd1R9) [[2]](diffhunk://#diff-2879311ce531e391c9c16a7e6a20f966629ea88f91d30ecbf7f0844f3ed63f0aR7)

**UART Start Logic Improvements:**

* Refined the UART start logic in `ciot_uart_start` to prevent changing the UART number without stopping the interface first, and improved logging and error returns for invalid state transitions. [[1]](diffhunk://#diff-c8a5a36ea012ff34598ad0ee6f74aaf1c434a0083acbc5a0c877c116db5bcceaL79-L100) [[2]](diffhunk://#diff-c8a5a36ea012ff34598ad0ee6f74aaf1c434a0083acbc5a0c877c116db5bcceaL113-R113) [[3]](diffhunk://#diff-c8a5a36ea012ff34598ad0ee6f74aaf1c434a0083acbc5a0c877c116db5bcceaR123-R125)

**Build Script Update:**

* Updated the `make/scripts.mk` script to use new environment variable names and the correct path for the MQTT translator script.

These changes collectively improve the robustness, observability, and maintainability of the MBUS server/client and UART components.