### PR TITLE
Feat/v0.21.0.2

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -25,3 +25,17 @@
 **Build Script Update:**
 
 * Updated the `make/scripts.mk` script to use new environment variable names and the correct path for the MQTT translator script.
+
+**Test coverage improvements**
+
+* Added new test data and a test case (`test_ciot_crypt_dec_ok_2`) to `ciot_crypt_test.c` for verifying decryption with a different key and input, increasing cryptographic test coverage. [[1]](diffhunk://#diff-4715a2e7f2ac8777d2b274311ac2cfb1e4459dc0144dba852cfb67e75ca3cfa6R26-R31) [[2]](diffhunk://#diff-4715a2e7f2ac8777d2b274311ac2cfb1e4459dc0144dba852cfb67e75ca3cfa6R154-R166) [[3]](diffhunk://#diff-4715a2e7f2ac8777d2b274311ac2cfb1e4459dc0144dba852cfb67e75ca3cfa6R201)
+
+**Bug fixes and functional improvements**
+
+* Moved the `uart_set_pin` call in `ciot_uart_start` so that UART pins are only set after checking if the UART is already started, preventing unnecessary hardware reconfiguration.
+* In `ciot_dfu_nrf_event_handler`, changed the event type check from `CIOT_EVENT_TYPE_MSG` to `CIOT_EVENT_TYPE_DATA` to correctly process incoming data events.
+* Improved the interface selection logic in `ciot_tcp_get_addr` (Windows): now only iterates network adapters if the TCP type is Ethernet or WiFi, and breaks out of the loop as soon as a connection is established, optimizing connection setup. [[1]](diffhunk://#diff-fd3885fdf60ec1ccd9aef56ede22dc496c00a524e4c0131e794d7aca2a5f1e8aR97-R102) [[2]](diffhunk://#diff-fd3885fdf60ec1ccd9aef56ede22dc496c00a524e4c0131e794d7aca2a5f1e8aR116-R127)
+
+**Version update**
+
+* Incremented the `CIOT_VER` macro to `0,21,0,2` to reflect these changes.

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,21,0,1
+#define CIOT_VER 0,21,0,2
 #define CIOT_IFACE_CFG_FILENAME "cfg%d.dat"
 
 #if defined(CIOT_TARGET_WIN) || defined(CIOT_TARGET_LINUX)

--- a/src/common/ciot_dfu_nrf.c
+++ b/src/common/ciot_dfu_nrf.c
@@ -612,7 +612,7 @@ static ciot_err_t ciot_dfu_nrf_event_handler(ciot_iface_t *sender, ciot_event_t 
         self->state = CIOT_DFU_NRF_STATE_SEND_PING;
     }
 
-    if (event->type == CIOT_EVENT_TYPE_DATA)
+    if (event->type == CIOT_EVENT_TYPE_DATA && event->which_data == CIOT_EVENT_DATA_RAW_TAG)
     {
         ciot_err_t err = ciot_dfu_nrf_process_response(self, event->raw.bytes, event->raw.size);
         if (err != CIOT_ERR_OK)

--- a/src/common/ciot_dfu_nrf.c
+++ b/src/common/ciot_dfu_nrf.c
@@ -612,7 +612,7 @@ static ciot_err_t ciot_dfu_nrf_event_handler(ciot_iface_t *sender, ciot_event_t 
         self->state = CIOT_DFU_NRF_STATE_SEND_PING;
     }
 
-    if (event->type == CIOT_EVENT_TYPE_MSG)
+    if (event->type == CIOT_EVENT_TYPE_DATA)
     {
         ciot_err_t err = ciot_dfu_nrf_process_response(self, event->raw.bytes, event->raw.size);
         if (err != CIOT_ERR_OK)

--- a/src/esp32/ciot_uart.c
+++ b/src/esp32/ciot_uart.c
@@ -84,8 +84,12 @@ ciot_err_t ciot_uart_start(ciot_uart_t self, ciot_uart_cfg_t *cfg)
 
     CIOT_LOGI(TAG, "num: %d", (int)cfg->num);
 
-    if (cfg->has_gpio == false)
+    if (cfg->has_gpio == false || base->status.state == CIOT_UART_STATE_STARTED)
     {
+        if(base->status.state == CIOT_UART_STATE_STARTED)
+        {
+            CIOT_LOGW(TAG, "UART already started. GPIO settings will be ignored");
+        }
         cfg->has_gpio = base->cfg.has_gpio;
         cfg->gpio = base->cfg.gpio;
     }

--- a/src/esp32/ciot_uart.c
+++ b/src/esp32/ciot_uart.c
@@ -102,14 +102,14 @@ ciot_err_t ciot_uart_start(ciot_uart_t self, ciot_uart_cfg_t *cfg)
     };
 
     ESP_ERROR_CHECK(uart_param_config(num, &uart_cfg));
-    ESP_ERROR_CHECK(uart_set_pin(num, base->cfg.gpio.tx, base->cfg.gpio.rx, base->cfg.gpio.rts, base->cfg.gpio.cts));
-
+    
     if (base->status.state == CIOT_UART_STATE_STARTED)
     {
         CIOT_LOGI(TAG, "UART already started");
     }
     else
     {
+        ESP_ERROR_CHECK(uart_set_pin(num, base->cfg.gpio.tx, base->cfg.gpio.rx, base->cfg.gpio.rts, base->cfg.gpio.cts));
         ESP_ERROR_CHECK(uart_driver_install(num, CIOT_CONFIG_UART_RX_BUF_SIZE, CIOT_CONFIG_UART_TX_BUF_SIZE, CIOT_CONFIG_UART_QUEUE_SIZE, &self->queue, 0));
         if (base->iface.decoder)
         {

--- a/src/win/ciot_tcp.c
+++ b/src/win/ciot_tcp.c
@@ -99,7 +99,8 @@ static ciot_err_t ciot_tcp_get_addr(ciot_tcp_t self)
         while (pCurr)
         {
             // Confere o tipo da interface conforme seu interesse
-            if (pCurr->IfType == IF_TYPE_ETHERNET_CSMACD || pCurr->IfType == IF_TYPE_IEEE80211)
+            if ((self->base.type == CIOT_TCP_TYPE_ETHERNET && pCurr->IfType == IF_TYPE_ETHERNET_CSMACD) ||
+                (self->base.type == CIOT_TCP_TYPE_WIFI_STA && pCurr->IfType == IF_TYPE_IEEE80211))
             {
                 // Verifica se existe endereço unicast
                 IP_ADAPTER_UNICAST_ADDRESS *pUnicast = pCurr->FirstUnicastAddress;

--- a/src/win/ciot_tcp.c
+++ b/src/win/ciot_tcp.c
@@ -94,29 +94,36 @@ static ciot_err_t ciot_tcp_get_addr(ciot_tcp_t self)
     }
 
     IP_ADAPTER_ADDRESSES *pCurr = pAddresses;
-    while (pCurr)
+    if(self->base.type == CIOT_TCP_TYPE_ETHERNET || self->base.type == CIOT_TCP_TYPE_WIFI_STA)
     {
-        // Confere o tipo da interface conforme seu interesse
-        if ((self->base.type == CIOT_TCP_TYPE_ETHERNET && pCurr->IfType == IF_TYPE_ETHERNET_CSMACD) ||
-            (self->base.type == CIOT_TCP_TYPE_WIFI_STA && pCurr->IfType == IF_TYPE_IEEE80211))
+        while (pCurr)
         {
-            // Verifica se existe endereço unicast
-            IP_ADAPTER_UNICAST_ADDRESS *pUnicast = pCurr->FirstUnicastAddress;
-            while (pUnicast)
+            // Confere o tipo da interface conforme seu interesse
+            if (pCurr->IfType == IF_TYPE_ETHERNET_CSMACD || pCurr->IfType == IF_TYPE_IEEE80211)
             {
-                SOCKADDR *sa = pUnicast->Address.lpSockaddr;
-                if (sa->sa_family == AF_INET && pUnicast->DadState == NldsPreferred)
-                { // IPv4
-                    struct sockaddr_in *sa_in = (struct sockaddr_in *)sa;
-                    memcpy(self->base.info->ip, &(sa_in->sin_addr), 4);
-                    self->base.status->state = CIOT_TCP_STATE_CONNECTED;
-                    self->base.status->conn_count++;
-                    ciot_iface_send_event_type(self->base.iface, CIOT_EVENT_TYPE_STARTED);
+                // Verifica se existe endereço unicast
+                IP_ADAPTER_UNICAST_ADDRESS *pUnicast = pCurr->FirstUnicastAddress;
+                while (pUnicast)
+                {
+                    SOCKADDR *sa = pUnicast->Address.lpSockaddr;
+                    if (sa->sa_family == AF_INET && pUnicast->DadState == NldsPreferred)
+                    { // IPv4
+                        struct sockaddr_in *sa_in = (struct sockaddr_in *)sa;
+                        memcpy(self->base.info->ip, &(sa_in->sin_addr), 4);
+                        self->base.status->state = CIOT_TCP_STATE_CONNECTED;
+                        self->base.status->conn_count++;
+                        ciot_iface_send_event_type(self->base.iface, CIOT_EVENT_TYPE_STARTED);
+                        break;
+                    }
+                    pUnicast = pUnicast->Next;
                 }
-                pUnicast = pUnicast->Next;
+                if(self->base.status->state == CIOT_TCP_STATE_CONNECTED)
+                {
+                    break;
+                }
             }
+            pCurr = pCurr->Next;
         }
-        pCurr = pCurr->Next;
     }
 
     if(self->base.status->state != CIOT_TCP_STATE_CONNECTED)

--- a/tests/common/ciot_crypt_test.c
+++ b/tests/common/ciot_crypt_test.c
@@ -23,6 +23,12 @@
 #define CIOT_CRYPT_DATA_DECRYPTED "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat"
 #define CIOT_CRYPT_DATA_ENCRYPTED "YFGMkV1Cyz4ipXOXE6jw27qv4BCWYnJdwNnRIFVpJKe+k9CMC/j1KLPb801/eo9Hieb5D8Y6Npng08DbEU7wpYRYpB6wBn2NTql3qIkhYYvQzsPi9rY3gZtMBpe+5MV83d71wUEgGVnsu224gvCmOG0ATRhTu5ltNq6AICqw+fyScYexCTVP2aEDNIp+13WcD1LSkNOO6xWyOlSH4xhbsJGDLMq379g3IEoDS9CltUrO+vDlJ4EcNy72j6frD4KElPVgk9SgAbtqvyZ7vcwV3K5qK8GdpEVi7hpCQ9pQXskUL2oAnyR6U/A64xgu9G87"
 
+#define CIOT_CRYPT_VALID_KEY_2 (uint8_t*) "AABBCCDDEEFF4548"
+#define CIOT_CRYPT_VALID_KEY_2_SIZE 16
+
+#define CIOT_CRYPT_DATA_DECRYPTED_2 "testpassword"
+#define CIOT_CRYPT_DATA_ENCRYPTED_2 "UbcXb6GJEasJw9MQEnp8bw=="
+
 void test_ciot_crypt_enc_null_crypt(void)
 {
     char *data = CIOT_CRYPT_DATA_DECRYPTED;
@@ -145,6 +151,19 @@ void test_ciot_crypt_dec_ok(void)
     TEST_ASSERT(strcmp(out, CIOT_CRYPT_DATA_DECRYPTED) == 0);
 }
 
+void test_ciot_crypt_dec_ok_2(void)
+{
+    char out[sizeof(CIOT_CRYPT_DATA_ENCRYPTED_2)];
+    char *data = CIOT_CRYPT_DATA_ENCRYPTED_2;
+    ciot_crypt_t crypt = {
+        .key.data = CIOT_CRYPT_VALID_KEY_2,
+        .key.size = CIOT_CRYPT_VALID_KEY_2_SIZE,
+    };
+    ciot_err_t err = ciot_crypt_dec(&crypt, data, out, sizeof(out));
+    TEST_ASSERT(err == CIOT_ERR_OK);
+    TEST_ASSERT(strcmp(out, CIOT_CRYPT_DATA_DECRYPTED_2) == 0);
+}
+
 void test_ciot_crypt_pkcs7_padding(void)
 {
     const char *input = "1234567890abcdef";
@@ -179,5 +198,6 @@ void test_ciot_crypt(void)
     RUN_TEST(test_ciot_crypt_dec_invalid_key_size);
     RUN_TEST(test_ciot_crypt_dec_invalid_size);
     RUN_TEST(test_ciot_crypt_dec_ok);
+    RUN_TEST(test_ciot_crypt_dec_ok_2);
     RUN_TEST(test_ciot_crypt_pkcs7_padding);
 }


### PR DESCRIPTION
This pull request introduces several functional improvements and test enhancements across the codebase. The most significant changes include expanding cryptography unit tests, fixing UART initialization order, and improving TCP address selection logic.

### Test coverage improvements

* Added new test data and a test case (`test_ciot_crypt_dec_ok_2`) to `ciot_crypt_test.c` for verifying decryption with a different key and input, increasing cryptographic test coverage. [[1]](diffhunk://#diff-4715a2e7f2ac8777d2b274311ac2cfb1e4459dc0144dba852cfb67e75ca3cfa6R26-R31) [[2]](diffhunk://#diff-4715a2e7f2ac8777d2b274311ac2cfb1e4459dc0144dba852cfb67e75ca3cfa6R154-R166) [[3]](diffhunk://#diff-4715a2e7f2ac8777d2b274311ac2cfb1e4459dc0144dba852cfb67e75ca3cfa6R201)

### Bug fixes and functional improvements

* Moved the `uart_set_pin` call in `ciot_uart_start` so that UART pins are only set after checking if the UART is already started, preventing unnecessary hardware reconfiguration.
* In `ciot_dfu_nrf_event_handler`, changed the event type check from `CIOT_EVENT_TYPE_MSG` to `CIOT_EVENT_TYPE_DATA` to correctly process incoming data events.
* Improved the interface selection logic in `ciot_tcp_get_addr` (Windows): now only iterates network adapters if the TCP type is Ethernet or WiFi, and breaks out of the loop as soon as a connection is established, optimizing connection setup. [[1]](diffhunk://#diff-fd3885fdf60ec1ccd9aef56ede22dc496c00a524e4c0131e794d7aca2a5f1e8aR97-R102) [[2]](diffhunk://#diff-fd3885fdf60ec1ccd9aef56ede22dc496c00a524e4c0131e794d7aca2a5f1e8aR116-R127)

### Version update

* Incremented the `CIOT_VER` macro to `0,21,0,2` to reflect these changes.