### PR TITLE
fix: remove event queue implementation and update related functionality

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,55 +2,16 @@
 
 ### Changes
 
-**Core event handling and queueing:**
+**Event Handling Refactor:**
 
-* Replaced the previous `ciot_receiver` structure with a new event queue system (`ciot_event_queue_t` and `ciot_event_slot_t`), enabling buffered event processing and improved concurrency. The event queue now supports configurable size and tracks dropped events. (`[[1]](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554L73-R97)`, `[[2]](diffhunk://#diff-bebf3b3742ecc13fb8bff23dc362b537e593146621f52ab115c0c492d7459c74R73-R76)`, `[[3]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10R27-R122)`, `[[4]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L263-R383)`, `[[5]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L361-L377)`)
-* Updated `ciot_busy_task` and `ciot_starting_task` to process events from the queue, improving robustness and handling of unexpected or out-of-order events. (`[[1]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L263-R383)`, `[[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L361-L377)`, `[[3]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L397-L410)`, `[[4]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L462-R572)`, `[[5]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L482)`, `[[6]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L493-L504)`)
-* Introduced helper functions for queue operations, such as reserving, committing, pushing, and popping events, and handling raw event data deserialization. (`[src/core/ciot.cR27-R122](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10R27-R122)`)
+* Removed the `ciot_event_queue_t` structure and all associated event queue logic, including event slot management and queue push/pop functions. Events are now stored directly in the `ciot_receiver_t` struct, which holds only the latest event and its sender. (`include/ciot.h` [[1]](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554L74-R81) `src/core/ciot.c` [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L27-L122) [[3]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L352-L383) [[4]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L470-R377) [[5]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L683-R662)
+* Updated the event processing flow in `ciot_busy_task`, `ciot_starting_task`, and `ciot_iface_event_handler` to work with the new receiver-based event storage instead of queue-based logic. (`src/core/ciot.c` [[1]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L352-L383) [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L470-R377) [[3]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L683-R662)
 
-**BLE scanner and interface API updates:**
+**Configuration Management Improvements:**
 
-* Changed BLE scanner event handling to use a specific event type (`ciot_ble_scn_event_adv_report_t`) and updated related function signatures for clarity and correctness. (`[[1]](diffhunk://#diff-9cc3ff9f4c60d80c2855302798490b054d719bbcb6706bb5179002e28506ccbaL76-R76)`, `[[2]](diffhunk://#diff-1d56b9dfd453aa5d1584b74b104467528a195ea593194e1b200838f769b93ea2L139-R142)`, `[[3]](diffhunk://#diff-1d56b9dfd453aa5d1584b74b104467528a195ea593194e1b200838f769b93ea2L162-R161)`, `[[4]](diffhunk://#diff-1d56b9dfd453aa5d1584b74b104467528a195ea593194e1b200838f769b93ea2L195-R194)`)
-* Added `ciot_iface_send_event_data` function to the interface API, allowing direct sending of event data buffers. (`[include/ciot_iface.hR53](diffhunk://#diff-d81cd7438a00c22a4f450ac673da1c4398d739083d28a53d8b1a6bfde11f7558R53)`)
+* Replaced the hardcoded `CIOT_IFACE_CFG_FILENAME` macro with a configurable `CIOT_CONFIG_IFACE_CFG_FILENAME_MASK`, allowing the filename pattern to be overridden as needed. Updated all usages in the codebase. (`include/ciot.h` [[1]](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554L37-R40) `src/core/ciot.c` [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L226-R137) [[3]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L236-R147) [[4]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L256-R167) [[5]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L282-R193) [[6]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L301-R212) [[7]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L533-R424)
 
-**WiFi Multi-Connection Core Improvements**
+**Code Cleanup and Minor Changes:**
 
-* Introduced a new `ciot_wifi_multi_wifi_ops_t` structure, allowing injection of custom WiFi operations (start, stop, get_status, get_info) for greater flexibility and easier integration with different WiFi backends. Default implementations are provided and used if no custom ops are set. (`include/ciot_wifi_multi.h`, `src/common/ciot_wifi_multi_base.c`) [[1]](diffhunk://#diff-6cf31a1232ed8b6b5dc2edbe6c329bf3486d16f2ee281fdf267d20c99e339a1dR35-R47) [[2]](diffhunk://#diff-6cf31a1232ed8b6b5dc2edbe6c329bf3486d16f2ee281fdf267d20c99e339a1dR56-R57) [[3]](diffhunk://#diff-7a90ef6b5f3d860783c5c2ab5c25dd1f8738670d999aa3ef433eb0644765fdefR35-L41) [[4]](diffhunk://#diff-7a90ef6b5f3d860783c5c2ab5c25dd1f8738670d999aa3ef433eb0644765fdefL88-R133)
-* Added the `ciot_wifi_multi_set_wifi_ops` API and integrated it throughout the codebase, ensuring all WiFi operations use the ops interface for consistency and extensibility. (`include/ciot_wifi_multi.h`, `src/common/ciot_wifi_multi_base.c`) [[1]](diffhunk://#diff-6cf31a1232ed8b6b5dc2edbe6c329bf3486d16f2ee281fdf267d20c99e339a1dR77) [[2]](diffhunk://#diff-7a90ef6b5f3d860783c5c2ab5c25dd1f8738670d999aa3ef433eb0644765fdefL88-R133)
-* Improved state management by tracking whether the WiFi multi system has started, preventing invalid operations when not running and ensuring correct event handling. (`src/common/ciot_wifi_multi_base.c`) [[1]](diffhunk://#diff-7a90ef6b5f3d860783c5c2ab5c25dd1f8738670d999aa3ef433eb0644765fdefL151-R237) [[2]](diffhunk://#diff-7a90ef6b5f3d860783c5c2ab5c25dd1f8738670d999aa3ef433eb0644765fdefL170-R296) [[3]](diffhunk://#diff-7a90ef6b5f3d860783c5c2ab5c25dd1f8738670d999aa3ef433eb0644765fdefR360-R364) [[4]](diffhunk://#diff-7a90ef6b5f3d860783c5c2ab5c25dd1f8738670d999aa3ef433eb0644765fdefR404-R407) [[5]](diffhunk://#diff-7a90ef6b5f3d860783c5c2ab5c25dd1f8738670d999aa3ef433eb0644765fdefR420-R424) [[6]](diffhunk://#diff-7a90ef6b5f3d860783c5c2ab5c25dd1f8738670d999aa3ef433eb0644765fdefR579-R587)
-* Enhanced the switching logic to avoid unnecessary reconnections if already connected to the target SSID, and to retry all valid SSIDs in a round-robin fashion. (`src/common/ciot_wifi_multi_base.c`) (F2c20b99L634R684, [[1]](diffhunk://#diff-7a90ef6b5f3d860783c5c2ab5c25dd1f8738670d999aa3ef433eb0644765fdefR687-R695) [[2]](diffhunk://#diff-7a90ef6b5f3d860783c5c2ab5c25dd1f8738670d999aa3ef433eb0644765fdefL521-R723)
-
-**Configurability and API Additions**
-
-* Added `ciot_wifi_multi_set_item` API and integrated it into the request handling, allowing dynamic updates to individual WiFi configuration items. (`include/ciot_wifi_multi.h`, `src/common/ciot_wifi_multi_base.c`) [[1]](diffhunk://#diff-6cf31a1232ed8b6b5dc2edbe6c329bf3486d16f2ee281fdf267d20c99e339a1dR68) [[2]](diffhunk://#diff-7a90ef6b5f3d860783c5c2ab5c25dd1f8738670d999aa3ef433eb0644765fdefR306-R331) F2c20b99L470R470)
-
-**Build and Versioning**
-
-* Increased the default value of `CIOT_CONFIG_HTTP_SERVER_TIMEOUT_MS` from 15000 ms to 30000 ms in `ciot_http_server.c` to allow more time for HTTP server responses. New extended timeout is needed to support wifi reconnection attempts.
-
-**Build Script Update:**
-
-* Updated the `make/scripts.mk` script to use new environment variable names and the correct path for the MQTT translator script.
-
-**Test coverage improvements**
-
-* Added new test data and a test case (`test_ciot_crypt_dec_ok_2`) to `ciot_crypt_test.c` for verifying decryption with a different key and input, increasing cryptographic test coverage. [[1]](diffhunk://#diff-4715a2e7f2ac8777d2b274311ac2cfb1e4459dc0144dba852cfb67e75ca3cfa6R26-R31) [[2]](diffhunk://#diff-4715a2e7f2ac8777d2b274311ac2cfb1e4459dc0144dba852cfb67e75ca3cfa6R154-R166) [[3]](diffhunk://#diff-4715a2e7f2ac8777d2b274311ac2cfb1e4459dc0144dba852cfb67e75ca3cfa6R201)
-
-**Bug fixes and functional improvements**
-
-* Moved the `uart_set_pin` call in `ciot_uart_start` so that UART pins are only set after checking if the UART is already started, preventing unnecessary hardware reconfiguration.
-* In `ciot_dfu_nrf_event_handler`, changed the event type check from `CIOT_EVENT_TYPE_MSG` to `CIOT_EVENT_TYPE_DATA` to correctly process incoming data events.
-* Improved the interface selection logic in `ciot_tcp_get_addr` (Windows): now only iterates network adapters if the TCP type is Ethernet or WiFi, and breaks out of the loop as soon as a connection is established, optimizing connection setup. [[1]](diffhunk://#diff-fd3885fdf60ec1ccd9aef56ede22dc496c00a524e4c0131e794d7aca2a5f1e8aR97-R102) [[2]](diffhunk://#diff-fd3885fdf60ec1ccd9aef56ede22dc496c00a524e4c0131e794d7aca2a5f1e8aR116-R127)
-
-**WiFi reconnection and state management improvements:**
-
-* Added a `reconnect` flag to the `ciot_wifi_base_t` struct and implemented the `ciot_wifi_set_reconnect` function, allowing external configuration of automatic WiFi reconnection attempts (`include/ciot_wifi.h`, `src/common/ciot_wifi_base.c`). [[1]](diffhunk://#diff-ca06c9e501fbf825c6fd9ca3cd0cce0ce9db4ddb5c48c00c94d2c023ccb800d0R45) [[2]](diffhunk://#diff-ca06c9e501fbf825c6fd9ca3cd0cce0ce9db4ddb5c48c00c94d2c023ccb800d0R63) [[3]](diffhunk://#diff-eef672241b635d4c1209cc3ad8db038d86150871db5b6aaf036ec69d255125d5R206-R213)
-* Refactored the `ciot_wifi` struct and event handler logic by removing the `reconnecting` and `switching_network` state variables, consolidating connection attempt tracking, and simplifying reconnection flow (`src/esp32/ciot_wifi.c`). [[1]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279L31-R31) [[2]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279L225-L246) [[3]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279L397-L402) [[4]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279L429-L430) [[5]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279L445-R447)
-
-**Connection retry and event handling:**
-
-* Updated the connection retry logic to utilize the new `reconnect` flag, allowing continued reconnection attempts if enabled, and improved event signaling when stopping WiFi (`src/esp32/ciot_wifi.c`). [[1]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279R127-R132) [[2]](diffhunk://#diff-1e5fcda8059ac0f18c5557188647b0a89a590410665a42881e045675369a6279L445-R447)
-
-**Versioning:**
-
-* Bumped the `CIOT_VER` macro to `0,21,0,5` to reflect these changes (`include/ciot.h`).
+* Removed the now-unused `ciot_event_queue_t`, `ciot_event_slot_t`, and related macros and function declarations from headers and source files. (`include/ciot.h` [[1]](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554L74-R81) `src/core/ciot.c` [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L27-L122)
+* Updated version macro to `0,21,2,0`. (`include/ciot.h` [include/ciot.hL37-R40](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554L37-R40))

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -12,7 +12,6 @@
 #ifndef __CIOT__H__
 #define __CIOT__H__
 
-#include "ciot_config.h"
 #include "ciot_iface.h"
 #include "ciot_storage.h"
 #include "ciot_types.h"
@@ -34,8 +33,11 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,21,1,1
-#define CIOT_IFACE_CFG_FILENAME "cfg%d.dat"
+#define CIOT_VER 0,21,2,0
+
+#ifndef CIOT_CONFIG_IFACE_CFG_FILENAME_MASK
+#define CIOT_CONFIG_IFACE_CFG_FILENAME_MASK "cfg%d.dat"
+#endif
 
 #if defined(CIOT_TARGET_WIN) || defined(CIOT_TARGET_LINUX)
 #include "mongoose.h"
@@ -71,30 +73,12 @@ typedef struct ciot_starter
     uint64_t timer;
 } ciot_starter_t;
 
-typedef struct ciot_event_slot
-{
-    ciot_iface_t *sender;
-    ciot_event_t event;
-    bool truncated;
-} ciot_event_slot_t;
-
-#ifndef CIOT_CONFIG_EVENT_QUEUE_SIZE
-#define CIOT_CONFIG_EVENT_QUEUE_SIZE 16
-#endif
-
-typedef struct ciot_event_queue
-{
-    ciot_event_slot_t slots[CIOT_CONFIG_EVENT_QUEUE_SIZE];
-    uint8_t head;
-    uint8_t tail;
-    uint8_t count;
-    uint32_t dropped;
-} ciot_event_queue_t;
-
 typedef struct ciot_receiver
 {
+    bool serialized;
+    ciot_iface_t *sender;
     ciot_iface_t *proxy;
-    ciot_event_queue_t queue;
+    ciot_event_t event;
     uint64_t timeout_timer;
 } ciot_receiver_t;
 

--- a/src/core/ciot.c
+++ b/src/core/ciot.c
@@ -24,102 +24,13 @@
 #define CIOT_CONFIG_BUSY_TIMEOUT_SECS 30
 #endif
 
-#ifndef CIOT_CONFIG_EVENT_QUEUE_SIZE
-#define CIOT_CONFIG_EVENT_QUEUE_SIZE 16
-#endif
-
 static const char *TAG = "ciot";
 
 static ciot_err_t ciot_starting_task(ciot_t self);
 static ciot_err_t ciot_busy_task(ciot_t self);
 static ciot_err_t ciot_set_iface_list(ciot_t self, ciot_iface_t *ifaces[], int count);
-static ciot_err_t ciot_bytes_received(ciot_t self, ciot_iface_t *sender, uint8_t *bytes, int size, ciot_event_t *dst);
+static ciot_err_t ciot_bytes_received(ciot_t self, ciot_iface_t *sender, uint8_t *bytes, int size);
 static ciot_err_t ciot_iface_event_handler(ciot_iface_t *sender, ciot_event_t *event, void *event_args);
-static ciot_err_t ciot_event_queue_push_raw(ciot_t self, ciot_receiver_t *receiver, ciot_iface_t *sender, ciot_event_t *event, ciot_event_t **queued_event_out);
-
-static ciot_err_t ciot_event_queue_reserve_tail(ciot_event_queue_t *queue, ciot_event_slot_t **slot)
-{
-    if(queue->count >= CIOT_CONFIG_EVENT_QUEUE_SIZE)
-    {
-        CIOT_LOGE(TAG, "Event queue is full. Dropping event. total dropped: %lu", (long unsigned int)queue->dropped);
-        queue->dropped++;
-        return CIOT_ERR_BUSY;
-    }
-    *slot = &queue->slots[queue->tail];
-    return CIOT_ERR_OK;
-}
-
-static void ciot_event_queue_commit_tail(ciot_event_queue_t *queue)
-{
-    queue->tail = (queue->tail + 1) % CIOT_CONFIG_EVENT_QUEUE_SIZE;
-    queue->count++;
-}
-
-static ciot_err_t ciot_event_queue_push(ciot_event_queue_t *queue, ciot_iface_t *sender, ciot_event_t *event)
-{
-    ciot_event_slot_t *slot = NULL;
-    ciot_err_t err = ciot_event_queue_reserve_tail(queue, &slot);
-    if(err != CIOT_ERR_OK)
-    {
-        return err;
-    }
-    slot->sender = sender;
-    slot->event = *event;
-    slot->truncated = false;
-    ciot_event_queue_commit_tail(queue);
-    return CIOT_ERR_OK;
-}
-
-static ciot_err_t ciot_event_queue_push_raw(ciot_t self, ciot_receiver_t *receiver, ciot_iface_t *sender, ciot_event_t *event, ciot_event_t **queued_event_out)
-{
-    ciot_event_slot_t *slot = NULL;
-    ciot_err_t reserve_err = ciot_event_queue_reserve_tail(&receiver->queue, &slot);
-    if(reserve_err != CIOT_ERR_OK)
-    {
-        return reserve_err;
-    }
-
-    slot->sender = sender;
-    slot->truncated = false;
-    ciot_event_t *queued_event = &slot->event;
-    queued_event->type = event->type;
-
-    ciot_err_t deser_err = CIOT_ERR_OK;
-    if(event->which_data == CIOT_EVENT_RAW_TAG)
-    {
-        deser_err = ciot_bytes_received(self, sender, event->raw.bytes, event->raw.size, queued_event);
-    }
-    else if(event->which_data == CIOT_EVENT_MSG_TAG)
-    {
-        queued_event->msg = event->msg;
-        queued_event->which_data = CIOT_EVENT_MSG_TAG;
-    }
-    else
-    {
-        deser_err = CIOT_ERR_INVALID_TYPE;
-    }
-
-    if(deser_err != CIOT_ERR_OK)
-    {
-        return deser_err;
-    }
-
-    ciot_event_queue_commit_tail(&receiver->queue);
-    if(queued_event_out != NULL)
-    {
-        *queued_event_out = queued_event;
-    }
-    return CIOT_ERR_OK;
-}
-
-static bool ciot_event_queue_pop_into(ciot_event_queue_t *queue, ciot_event_slot_t *slot_out)
-{
-    if(queue->count == 0 || slot_out == NULL) return false;
-    *slot_out = queue->slots[queue->head];
-    queue->head = (queue->head + 1) % CIOT_CONFIG_EVENT_QUEUE_SIZE;
-    queue->count--;
-    return true;
-}
 
 #ifdef CIOT_MG_ENABLED
 struct mg_mgr mg;
@@ -223,7 +134,7 @@ ciot_err_t ciot_delete_cfg(ciot_t self, ciot_iface_info_t *iface)
     CIOT_ERR_NULL_CHECK(self->storage);
     CIOT_ERR_VALUE_CHECK(iface->type, self->ifaces.list[iface->id]->info.type, CIOT_ERR_INVALID_TYPE);
     char filename[16];
-    sprintf(filename, CIOT_IFACE_CFG_FILENAME, (int)iface->id);
+    sprintf(filename, CIOT_CONFIG_IFACE_CFG_FILENAME_MASK, (int)iface->id);
     CIOT_LOGI(TAG, "Deleting configuration: %s file: %s", ciot_iface_type_to_str(iface->type), filename);
     return self->storage->remove(self->storage, filename);
 }
@@ -233,7 +144,7 @@ ciot_err_t ciot_save_cfg(ciot_t self, ciot_iface_info_t *iface)
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(self->storage);
     char filename[16];
-    sprintf(filename, CIOT_IFACE_CFG_FILENAME, (int)iface->id);
+    sprintf(filename, CIOT_CONFIG_IFACE_CFG_FILENAME_MASK, (int)iface->id);
     ciot_iface_t *iface_instance = self->ifaces.list[iface->id];
     ciot_msg_t *msg = calloc(1, sizeof(ciot_msg_t));
     CIOT_ERR_MEMORY_CHECK(msg);
@@ -253,7 +164,7 @@ ciot_err_t ciot_load_cfg(ciot_t self, ciot_iface_info_t *iface, ciot_msg_data_t 
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(self->storage);
     char filename[16];
-    sprintf(filename, CIOT_IFACE_CFG_FILENAME, (int)iface->id);
+    sprintf(filename, CIOT_CONFIG_IFACE_CFG_FILENAME_MASK, (int)iface->id);
     return ciot_storage_load_data(self->storage, filename, cfg);
 }
 
@@ -279,7 +190,7 @@ ciot_err_t ciot_delete_all(ciot_t self)
     for (int i = 0; i < self->ifaces.count; i++)
     {
         char filename[32];
-        sprintf(filename, CIOT_IFACE_CFG_FILENAME, i);
+        sprintf(filename, CIOT_CONFIG_IFACE_CFG_FILENAME_MASK, i);
         ciot_err_t err = self->storage->remove(self->storage, filename);
         CIOT_LOGI(TAG, "Deleting configuration file: %s", filename);
         if(err != CIOT_ERR_OK) {
@@ -298,7 +209,7 @@ bool ciot_cfg_exists(ciot_t self, uint8_t iface_id)
     if(iface_id >= self->ifaces.count) return false;
     char filename[18];
     int size = 0;
-    sprintf(filename, CIOT_IFACE_CFG_FILENAME, iface_id);
+    sprintf(filename, CIOT_CONFIG_IFACE_CFG_FILENAME_MASK, iface_id);
     self->storage->read_bytes(self->storage, filename, NULL, &size);
     return size > 0;
 }
@@ -349,37 +260,17 @@ static ciot_err_t ciot_starting_task(ciot_t self)
 
     if (starter->waiting_result)
     {
-        ciot_event_slot_t slot = { 0 };
-        if (ciot_event_queue_pop_into(&receiver->queue, &slot))
+        if (receiver->sender != NULL &&
+            ciot_iface_event_is_ack(receiver->event.type) &&
+            starter->iface_id == receiver->sender->info.id)
         {
-            if (slot.sender != NULL &&
-                ciot_iface_event_is_ack(slot.event.type) &&
-                starter->iface_id == slot.sender->info.id)
+            CIOT_LOGI(TAG, "Interface [%lu]:%s evt %s received", (long unsigned int)receiver->sender->info.id, ciot_iface_to_str(receiver->sender), ciot_event_to_str(&receiver->event));
+            if(self->iface.event_handler != NULL)
             {
-                CIOT_LOGI(TAG, "Interface [%lu]:%s evt %s received", (long unsigned int)slot.sender->info.id, ciot_iface_to_str(slot.sender), ciot_event_to_str(&slot.event));
-                if(self->iface.event_handler != NULL)
-                {
-                    self->iface.event_handler(slot.sender, &slot.event, self->iface.event_args);
-                }
-                starter->iface_id++;
-                starter->waiting_result = false;
+                self->iface.event_handler(receiver->sender, &receiver->event, self->iface.event_args);
             }
-            else
-            {
-                if(slot.sender != NULL)
-                {
-                    CIOT_LOGW(TAG, "Discarding unexpected event while waiting start ACK. expected iface:%lu got iface:%lu evt:%s",
-                        (long unsigned int)starter->iface_id,
-                        (long unsigned int)slot.sender->info.id,
-                        ciot_event_to_str(&slot.event));
-                }
-                else
-                {
-                    CIOT_LOGW(TAG, "Discarding unexpected event while waiting start ACK. expected iface:%lu got null sender evt:%s",
-                        (long unsigned int)starter->iface_id,
-                        ciot_event_to_str(&slot.event));
-                }
-            }
+            starter->iface_id++;
+            starter->waiting_result = false;
         }
         else if (ciot_timer_compare(&starter->timer, CIOT_CONFIG_START_TIMEOUT_SECS))
         {
@@ -467,30 +358,22 @@ static ciot_err_t ciot_busy_task(ciot_t self)
         return CIOT_ERR_TIMEOUT;
     }
 
-    ciot_event_slot_t slot = { 0 };
-    if(!ciot_event_queue_pop_into(&receiver->queue, &slot))
+    if(self->status.state == CIOT_STATE_PENDING_EVENT && self->receiver.event.msg.iface.id < self->ifaces.count)
     {
-        self->status.state = CIOT_STATE_STARTED;
-        return CIOT_ERR_OK;
-    }
-
-    ciot_event_t *event = &slot.event;
-    ciot_iface_t *sender = slot.sender;
-
-    if(self->status.state == CIOT_STATE_PENDING_EVENT && event->which_data == CIOT_EVENT_MSG_TAG && event->msg.iface.id < self->ifaces.count)
-    {
+        receiver->sender = self->ifaces.list[self->receiver.event.msg.iface.id];
         self->status.state = CIOT_STATE_BUSY;
         receiver->timeout_timer = ciot_timer_now() + CIOT_CONFIG_BUSY_TIMEOUT_SECS;
     }
 
-    if (sender == NULL)
+    if (receiver->sender == NULL)
     {
         CIOT_LOGE(TAG, "Sender is null");
-        self->status.state = receiver->queue.count > 0
-            ? CIOT_STATE_BUSY
-            : CIOT_STATE_STARTED;
+        self->status.state = CIOT_STATE_STARTED;
         return CIOT_ERR_NULL_ARG;
     }
+
+    ciot_event_t *event = &receiver->event;
+    ciot_iface_t *sender = receiver->sender;
 
     if (sender->req_status.state != CIOT_IFACE_REQ_STATE_IDLE && (event->which_data == CIOT_EVENT_MSG_TAG))
     {
@@ -511,12 +394,20 @@ static ciot_err_t ciot_busy_task(ciot_t self)
         if ((ciot_iface_event_is_ack(event->type) || event->type == CIOT_EVENT_TYPE_MSG) &&
             iface_is_equal)
         {
+            // if (sender->req_status.id == event->msg.id)
+            // {
+            //     CIOT_LOGI(TAG, "Request done");
+            //     event->type = CIOT_EVENT_TYPE_DONE;
+            // }
+            // else
+            // {
                 CIOT_LOGI(TAG, "Response sended");
                 ciot_event_type_t prev_type = event->type;
                 event->msg.id = sender->req_status.id;
                 event->type = CIOT_EVENT_TYPE_DONE;
                 ciot_iface_send_rsp(self->ifaces.list[sender->req_status.iface.id], &event->msg);
                 event->type = prev_type;
+            // }
             sender->req_status.state = CIOT_IFACE_REQ_STATE_IDLE;
         }
         CIOT_LOGI(TAG, "Event processed");
@@ -530,7 +421,7 @@ static ciot_err_t ciot_busy_task(ciot_t self)
             {
                 if(event->msg.has_proxy == true && ciot_iface_is_equal(&self->iface.info, &event->msg.proxy.iface) && ciot_iface_is_equal(&self->ifaces.list[event->msg.iface.id]->info, &event->msg.iface) && event->msg.proxy.save) {
                     char filename[16];
-                    sprintf(filename, CIOT_IFACE_CFG_FILENAME, (int)event->msg.iface.id);
+                    sprintf(filename, CIOT_CONFIG_IFACE_CFG_FILENAME_MASK, (int)event->msg.iface.id);
                     event->msg.error = ciot_storage_save_data(self->storage, filename, &event->msg.data);
                     event->msg.proxy.state = CIOT_PROXY_STATE_PROXY_STATE_SENT;
                     ciot_iface_send_rsp(sender, &event->msg);
@@ -568,8 +459,9 @@ static ciot_err_t ciot_busy_task(ciot_t self)
                 {
                     // Direct request handling
                     CIOT_LOGI(TAG, "Processing request from %s", ciot_iface_to_str(sender));
+                    // CIOT_LOG_MSG_P(TAG, CIOT_LOGV, "RX REQ <- ", sender, event->msg);
                     uint8_t id = event->msg.iface.id;
-                    if (id < self->ifaces.count)
+                    if (id < self->ifaces.count /*&& event->msg->type <= CIOT__MSG_TYPE__MSG_TYPE_REQUEST*/)
                     {
                         ciot_iface_t *iface = self->ifaces.list[id];
                         if (iface != NULL)
@@ -587,6 +479,7 @@ static ciot_err_t ciot_busy_task(ciot_t self)
                             event->type = CIOT_EVENT_TYPE_ERROR;
                             ciot_iface_send_error(sender, CIOT_IFACE_TYPE_UNDEFINED, id, &event->msg, CIOT_ERR_NULL_ARG);
                         }
+            
                     }
                 }
             }
@@ -597,15 +490,18 @@ static ciot_err_t ciot_busy_task(ciot_t self)
         }
     }
 
-    self->status.state = receiver->queue.count > 0
-        ? CIOT_STATE_BUSY
-        : CIOT_STATE_STARTED;
+    receiver->sender = NULL;
+    
+    self->status.state = self->status.state != CIOT_STATE_PENDING_EVENT
+    ? CIOT_STATE_STARTED
+    : CIOT_STATE_PENDING_EVENT;
     
     if(self->iface.event_handler != NULL && (event->msg.has_proxy == false || event->msg.proxy.state == CIOT_PROXY_STATE_READY_TO_PROCESS))
     {
         self->iface.event_handler(sender, event, self->iface.event_args);
     }
     
+    event->msg.has_proxy = false;
     CIOT_LOGI(TAG, "ciot done");
 
     return CIOT_ERR_OK;
@@ -680,69 +576,62 @@ static ciot_err_t ciot_iface_event_handler(ciot_iface_t *sender, ciot_event_t *e
         return self->iface.event_handler(sender, event, self->iface.event_args);
     }
 
+    if (self->status.state == CIOT_STATE_BUSY)
+    {
+        if(ciot_iface_is_equal(&event->msg.iface, &receiver->event.msg.iface))
+        {
+            CIOT_LOGI(TAG, "ciot busy but event from same iface. processing...");
+            self->status.state = CIOT_STATE_PENDING_EVENT;
+        }
+        else
+        {
+            CIOT_LOGE(TAG, "ciot busy. %s(%lu) evt:%s ignored", ciot_iface_to_str(sender), (long unsigned int)sender->info.id, ciot_event_to_str(event));
+            return CIOT_ERR_BUSY;
+        }
+    }
+
+    receiver->event = *event;
+    receiver->sender = sender;
+    
     if (event->type == CIOT_EVENT_TYPE_MSG)
     {
-        if (self->status.state != CIOT_STATE_STARTED &&
-            self->status.state != CIOT_STATE_BUSY &&
-            self->status.state != CIOT_STATE_PENDING_EVENT)
+        if (self->status.state != CIOT_STATE_STARTED)
         {
             CIOT_LOGE(TAG, "ciot core is not started");
             return CIOT_ERR_BUSY;
         }
 
-        ciot_event_t *queued_event = NULL;
-        ciot_err_t queue_err = ciot_event_queue_push_raw(self, receiver, sender, event, &queued_event);
-
-        if(queue_err != CIOT_ERR_OK)
-        {
-            if(queue_err == CIOT_ERR_BUSY)
-            {
-                CIOT_LOGE(TAG, "ciot busy. %s(%lu) evt:%s dropped (queue full)", ciot_iface_to_str(sender), (long unsigned int)sender->info.id, ciot_event_to_str(event));
-            }
-            return queue_err;
-        }
+        CIOT_ERR_RETURN(ciot_bytes_received(self, sender, event->raw.bytes, event->raw.size));
 
 #if CIOT_CONFIG_FEATURE_LOG == 1
-        if(queued_event->msg.data.which_type == CIOT_MSG_DATA_LOG_TAG)
+        if(receiver->event.msg.data.which_type == CIOT_MSG_DATA_LOG_TAG)
         {
-            ciot_log_data_t *log = &queued_event->msg.data.log;
+            ciot_log_data_t *log = &receiver->event.msg.data.log;
             if(log->level == CIOT_LOG_LEVEL_INFO) CIOT_LOGI(TAG, "[%s] %s", log->tag, log->message);
             if(log->level == CIOT_LOG_LEVEL_WARNING) CIOT_LOGW(TAG, "[%s] %s", log->tag, log->message);
             if(log->level == CIOT_LOG_LEVEL_ERROR) CIOT_LOGE(TAG, "[%s] %s", log->tag, log->message);
         }
-#endif
+#endif 
 
-        if(queued_event->msg.iface.type == CIOT_IFACE_TYPE_CUSTOM &&
-           queued_event->msg.has_proxy == false)
+        if(receiver->event.msg.iface.type == CIOT_IFACE_TYPE_CUSTOM &&
+           receiver->event.msg.has_proxy == false)
         {
-            ciot_event_slot_t custom_slot = { 0 };
-            if(!ciot_event_queue_pop_into(&receiver->queue, &custom_slot))
-            {
-                CIOT_LOGE(TAG, "custom event dequeue failed");
-                return CIOT_ERR_FAIL;
-            }
-
-            ciot_event_t *custom_event = &custom_slot.event;
-            ciot_iface_t *custom_sender = custom_slot.sender;
-
             if(self->iface.event_handler != NULL)
             {
-                ciot_err_t err = self->iface.event_handler(custom_sender, custom_event, self->iface.event_args);
+                ciot_err_t err = self->iface.event_handler(sender, &receiver->event, self->iface.event_args);
                 if(err != CIOT_ERR_OK)
                 {
                     CIOT_LOGE(TAG, "error from application event handler: %s", ciot_err_to_message(err));
-                    ciot_iface_send_error(custom_sender, custom_event->msg.iface.type, custom_event->msg.iface.id, &custom_event->msg, err);
+                    ciot_iface_send_error(receiver->sender, receiver->event.msg.iface.type, receiver->event.msg.iface.type, &receiver->event.msg, err);
                 }
             }
             else
             {
                 CIOT_LOGE(TAG, "ciot event handler is null");
-                ciot_iface_send_error(custom_sender, CIOT_IFACE_TYPE_CIOT, self->iface.info.id, &custom_event->msg, CIOT_ERR_NULL_EVENT_HANDLER);
+                ciot_iface_send_error(receiver->sender, CIOT_IFACE_TYPE_CIOT, self->iface.info.id, &receiver->event.msg, CIOT_ERR_NULL_EVENT_HANDLER);
             }
-            return CIOT_ERR_OK;
         }
-
-        if (self->status.state == CIOT_STATE_STARTED)
+        else
         {
             self->status.state = CIOT_STATE_BUSY;
             receiver->timeout_timer = ciot_timer_now() + CIOT_CONFIG_BUSY_TIMEOUT_SECS;
@@ -750,42 +639,27 @@ static ciot_err_t ciot_iface_event_handler(ciot_iface_t *sender, ciot_event_t *e
     }
     else if(self->status.state == CIOT_STATE_STARTED)
     {
-        ciot_err_t push_err = ciot_event_queue_push(&receiver->queue, sender, event);
-        if(push_err != CIOT_ERR_OK)
-        {
-            CIOT_LOGE(TAG, "ciot busy. %s(%lu) evt:%s dropped (queue full)", ciot_iface_to_str(sender), (long unsigned int)sender->info.id, ciot_event_to_str(event));
-            return push_err;
-        }
         CIOT_LOGI(TAG, "Event received from %s", ciot_iface_to_str(sender));
+        receiver->sender = sender;
         self->status.state = CIOT_STATE_BUSY;
         receiver->timeout_timer = ciot_timer_now() + CIOT_CONFIG_BUSY_TIMEOUT_SECS;
-    }
-    else
-    {
-        // ACK events (started/stopped/error/done) received while BUSY go into the queue
-        ciot_err_t push_err = ciot_event_queue_push(&receiver->queue, sender, event);
-        if(push_err != CIOT_ERR_OK)
-        {
-            CIOT_LOGE(TAG, "ciot busy. %s(%lu) evt:%s dropped (queue full)", ciot_iface_to_str(sender), (long unsigned int)sender->info.id, ciot_event_to_str(event));
-            return push_err;
-        }
     }
 
     return CIOT_ERR_OK;
 }
 
-static ciot_err_t ciot_bytes_received(ciot_t self, ciot_iface_t *sender, uint8_t *bytes, int size, ciot_event_t *dst)
+static ciot_err_t ciot_bytes_received(ciot_t self, ciot_iface_t *sender, uint8_t *bytes, int size)
 {
     if(sender->serializer != NULL)
     {
-        sender->serializer->from_bytes(bytes, size, &dst->msg);
-        dst->which_data = CIOT_EVENT_MSG_TAG;
+        sender->serializer->from_bytes(bytes, size, &self->receiver.event.msg);
+        self->receiver.event.which_data = CIOT_EVENT_MSG_TAG;
         return CIOT_ERR_OK;
     }
     else
     {
-        ciot_serializer_from_bytes(bytes, size, &dst->msg, CIOT_MSG_FIELDS);
-        dst->which_data = CIOT_EVENT_MSG_TAG;
+        ciot_serializer_from_bytes(bytes, size, &self->receiver.event.msg, CIOT_MSG_FIELDS);
+        self->receiver.event.which_data = CIOT_EVENT_MSG_TAG;
         return CIOT_ERR_OK;
     }
 }


### PR DESCRIPTION
This pull request refactors the CIOT event handling system, removing the event queue mechanism and simplifying how interface events are processed and stored. It also introduces more flexible configuration filename handling and updates all related usages. The main goal is to streamline event management, reduce code complexity, and make configuration handling more customizable.

**Event Handling Refactor:**

* Removed the `ciot_event_queue_t` structure and all associated event queue logic, including event slot management and queue push/pop functions. Events are now stored directly in the `ciot_receiver_t` struct, which holds only the latest event and its sender. (`include/ciot.h` [[1]](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554L74-R81) `src/core/ciot.c` [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L27-L122) [[3]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L352-L383) [[4]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L470-R377) [[5]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L683-R662)
* Updated the event processing flow in `ciot_busy_task`, `ciot_starting_task`, and `ciot_iface_event_handler` to work with the new receiver-based event storage instead of queue-based logic. (`src/core/ciot.c` [[1]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L352-L383) [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L470-R377) [[3]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L683-R662)

**Configuration Management Improvements:**

* Replaced the hardcoded `CIOT_IFACE_CFG_FILENAME` macro with a configurable `CIOT_CONFIG_IFACE_CFG_FILENAME_MASK`, allowing the filename pattern to be overridden as needed. Updated all usages in the codebase. (`include/ciot.h` [[1]](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554L37-R40) `src/core/ciot.c` [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L226-R137) [[3]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L236-R147) [[4]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L256-R167) [[5]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L282-R193) [[6]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L301-R212) [[7]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L533-R424)

**Code Cleanup and Minor Changes:**

* Removed the now-unused `ciot_event_queue_t`, `ciot_event_slot_t`, and related macros and function declarations from headers and source files. (`include/ciot.h` [[1]](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554L74-R81) `src/core/ciot.c` [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L27-L122)
* Updated version macro to `0,21,2,0`. (`include/ciot.h` [include/ciot.hL37-R40](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554L37-R40))

These changes simplify the event handling logic, making the code easier to maintain and less error-prone, while also improving configuration flexibility.