### PR TITLE
Fix/mqtt client

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,16 +2,8 @@
 
 ### Changes
 
-**Event Handling Refactor:**
+MQTT client event handling improvements:
+* Set the `base->status.state` to `CIOT_MQTT_CLIENT_STATE_DISCONNECTED` when an MQTT disconnection event occurs in both `ciot_mqtt_client.c` for ESP32 and ESP8266. This ensures the client state accurately reflects the disconnected status. [[1]](diffhunk://#diff-f8eaf168fd7e70a563ff15acc977930908baa391c7a476f3d605cf857af68974R144) [[2]](diffhunk://#diff-b22fe51bd53f8103fe2b667c21cdf608a57f4dd05d97e316f7097f0c507c88e4R133)
 
-* Removed the `ciot_event_queue_t` structure and all associated event queue logic, including event slot management and queue push/pop functions. Events are now stored directly in the `ciot_receiver_t` struct, which holds only the latest event and its sender. (`include/ciot.h` [[1]](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554L74-R81) `src/core/ciot.c` [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L27-L122) [[3]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L352-L383) [[4]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L470-R377) [[5]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L683-R662)
-* Updated the event processing flow in `ciot_busy_task`, `ciot_starting_task`, and `ciot_iface_event_handler` to work with the new receiver-based event storage instead of queue-based logic. (`src/core/ciot.c` [[1]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L352-L383) [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L470-R377) [[3]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L683-R662)
-
-**Configuration Management Improvements:**
-
-* Replaced the hardcoded `CIOT_IFACE_CFG_FILENAME` macro with a configurable `CIOT_CONFIG_IFACE_CFG_FILENAME_MASK`, allowing the filename pattern to be overridden as needed. Updated all usages in the codebase. (`include/ciot.h` [[1]](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554L37-R40) `src/core/ciot.c` [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L226-R137) [[3]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L236-R147) [[4]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L256-R167) [[5]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L282-R193) [[6]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L301-R212) [[7]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L533-R424)
-
-**Code Cleanup and Minor Changes:**
-
-* Removed the now-unused `ciot_event_queue_t`, `ciot_event_slot_t`, and related macros and function declarations from headers and source files. (`include/ciot.h` [[1]](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554L74-R81) `src/core/ciot.c` [[2]](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10L27-L122)
-* Updated version macro to `0,21,2,0`. (`include/ciot.h` [include/ciot.hL37-R40](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554L37-R40))
+Version update:
+* Updated the `CIOT_VER` macro in `ciot.h` from `0,21,2,0` to `0,21,2,1` to reflect the new version.

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,21,2,0
+#define CIOT_VER 0,21,2,1
 
 #ifndef CIOT_CONFIG_IFACE_CFG_FILENAME_MASK
 #define CIOT_CONFIG_IFACE_CFG_FILENAME_MASK "cfg%d.dat"

--- a/src/esp32/ciot_mqtt_client.c
+++ b/src/esp32/ciot_mqtt_client.c
@@ -141,6 +141,7 @@ static void ciot_mqtt_event_handler(void *handler_args, esp_event_base_t event_b
         break;
     case MQTT_EVENT_DISCONNECTED:
         ESP_LOGI(TAG, "MQTT_EVENT_DISCONNECTED");
+        base->status.state = CIOT_MQTT_CLIENT_STATE_DISCONNECTED;
         ciot_iface_send_event_type(&base->iface, CIOT_EVENT_TYPE_STOPPED);
         break;
     case MQTT_EVENT_SUBSCRIBED:

--- a/src/esp8266/ciot_mqtt_client.c
+++ b/src/esp8266/ciot_mqtt_client.c
@@ -130,6 +130,7 @@ static void ciot_mqtt_event_handler(void *handler_args, esp_event_base_t event_b
         break;
     case MQTT_EVENT_DISCONNECTED:
         ESP_LOGI(TAG, "MQTT_EVENT_DISCONNECTED");
+        base->status.state = CIOT_MQTT_CLIENT_STATE_DISCONNECTED;
         ciot_iface_send_event_type(&base->iface, CIOT_EVENT_TYPE_STOPPED);
         break;
     case MQTT_EVENT_SUBSCRIBED:


### PR DESCRIPTION
This pull request includes a version bump and improves the handling of MQTT disconnection events in both ESP32 and ESP8266 MQTT client implementations. The main changes are as follows:

MQTT client event handling improvements:
* Set the `base->status.state` to `CIOT_MQTT_CLIENT_STATE_DISCONNECTED` when an MQTT disconnection event occurs in both `ciot_mqtt_client.c` for ESP32 and ESP8266. This ensures the client state accurately reflects the disconnected status. [[1]](diffhunk://#diff-f8eaf168fd7e70a563ff15acc977930908baa391c7a476f3d605cf857af68974R144) [[2]](diffhunk://#diff-b22fe51bd53f8103fe2b667c21cdf608a57f4dd05d97e316f7097f0c507c88e4R133)

Version update:
* Updated the `CIOT_VER` macro in `ciot.h` from `0,21,2,0` to `0,21,2,1` to reflect the new version.