### PR TITLE
fix: improve AP client connection handling and logging

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,8 +2,8 @@
 
 ### Changes
 
-MQTT client event handling improvements:
-* Set the `base->status.state` to `CIOT_MQTT_CLIENT_STATE_DISCONNECTED` when an MQTT disconnection event occurs in both `ciot_mqtt_client.c` for ESP32 and ESP8266. This ensures the client state accurately reflects the disconnected status. [[1]](diffhunk://#diff-f8eaf168fd7e70a563ff15acc977930908baa391c7a476f3d605cf857af68974R144) [[2]](diffhunk://#diff-b22fe51bd53f8103fe2b667c21cdf608a57f4dd05d97e316f7097f0c507c88e4R133)
+**Wi-Fi AP client management improvements:**
 
-Version update:
-* Updated the `CIOT_VER` macro in `ciot.h` from `0,21,2,0` to `0,21,2,1` to reflect the new version.
+* Added logging to show the current number of AP clients whenever a client connects or disconnects, making it easier to monitor client activity.
+* Ensured that the AP client count (`conn_count`) is decremented only when greater than zero, preventing negative counts.
+* Updated the AP state to `CIOT_TCP_STATE_CONNECTED` if there are still clients connected, or to `CIOT_TCP_STATE_STARTED` if no clients remain, ensuring the AP state accurately reflects the connection status.

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,21,2,1
+#define CIOT_VER 0,21,2,2
 
 #ifndef CIOT_CONFIG_IFACE_CFG_FILENAME_MASK
 #define CIOT_CONFIG_IFACE_CFG_FILENAME_MASK "cfg%d.dat"

--- a/src/esp32/ciot_wifi.c
+++ b/src/esp32/ciot_wifi.c
@@ -331,15 +331,21 @@ static void ciot_wifi_ap_event_handler(void *handler_args, esp_event_base_t even
         tcp->status->state = CIOT_TCP_STATE_CONNECTED;
         tcp->status->conn_count++;
         base->status.disconnect_reason = 0;
+        CIOT_LOGI(TAG, "AP clients: %u", (unsigned int)tcp->status->conn_count);
         ciot_iface_send_event_type(&base->iface, CIOT_WIFI_EVENT_AP_STA_CONNECTED);
         break;
     }
     case WIFI_EVENT_AP_STADISCONNECTED:
     {
         CIOT_LOGI(TAG, "WIFI_EVENT_AP_STADISCONNECTED");
-        tcp->status->state = CIOT_TCP_STATE_STARTED;
         base->status.disconnect_reason = ((wifi_event_ap_stadisconnected_t*)event_data)->reason;
         CIOT_LOGI(TAG, "reason: %u", (unsigned int)base->status.disconnect_reason);
+        if(tcp->status->conn_count > 0)
+        {
+            tcp->status->conn_count--;
+        }
+        CIOT_LOGI(TAG, "AP clients: %u", (unsigned int)tcp->status->conn_count);
+        tcp->status->state = tcp->status->conn_count > 0 ? CIOT_TCP_STATE_CONNECTED : CIOT_TCP_STATE_STARTED;
         ciot_iface_send_event_type(&base->iface, CIOT_WIFI_EVENT_AP_STA_DISCONNECTED);
         break;
     }


### PR DESCRIPTION
This pull request improves the handling of Wi-Fi Access Point (AP) client connections and disconnections in the `ciot_wifi_ap_event_handler` function. The main focus is on accurately tracking the number of connected clients and updating the connection state accordingly.

**Wi-Fi AP client management improvements:**

* Added logging to show the current number of AP clients whenever a client connects or disconnects, making it easier to monitor client activity.
* Ensured that the AP client count (`conn_count`) is decremented only when greater than zero, preventing negative counts.
* Updated the AP state to `CIOT_TCP_STATE_CONNECTED` if there are still clients connected, or to `CIOT_TCP_STATE_STARTED` if no clients remain, ensuring the AP state accurately reflects the connection status.