### PR TITLE
Feat/gpio

### DIFF
--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,24,0,0
+#define CIOT_VER 0,24,0,1
 
 #ifndef CIOT_CONFIG_IFACE_CFG_FILENAME_MASK
 #define CIOT_CONFIG_IFACE_CFG_FILENAME_MASK "cfg%d.dat"

--- a/src/common/ciot_gpio_base.c
+++ b/src/common/ciot_gpio_base.c
@@ -50,7 +50,7 @@ ciot_err_t ciot_gpio_task(ciot_gpio_t self)
         base->timer = ciot_timer_millis() + base->cfg.blink_interval;
         
         base->blink_signal     = (base->blink_tick >> 0) & 1;
-        bool slow_blink_signal = (base->blink_tick >> 2) & 1;
+        bool slow_blink_signal = (base->blink_tick >> 1) & 1;
         base->blink_tick++;
 
         if(base->blinking)


### PR DESCRIPTION
This pull request contains a minor version update and a small bug fix related to GPIO blinking logic.

- Version update:
  * Incremented the patch version in `CIOT_VER` from `0,24,0,0` to `0,24,0,1` in `ciot.h`.

- GPIO blinking logic fix:
  * Corrected the calculation of `slow_blink_signal` in `ciot_gpio_base.c` by shifting `blink_tick` by 1 instead of 2, ensuring the slow blink signal toggles at the intended rate.