### PR TITLE
Feat/nrf

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,12 +2,14 @@
 
 ### Changes
 
-**Enhancements to GPIO blinking functionality:**
+**BLE SCN Advertisement FIFO Improvements:**
 
-* Added two new GPIO states: `CIOT_GPIO_STATE_BLINKING_REVERSE` (alternates state in reverse phase) and `CIOT_GPIO_STATE_BLINKING_SLOW` (alternates state at half speed), and updated the enum helpers accordingly. [[1]](diffhunk://#diff-ef3b99b04bb0fd99e2e8aac7e8d21ff36127ce6229ac4352527520c64c57cd56L20-R22) [[2]](diffhunk://#diff-ef3b99b04bb0fd99e2e8aac7e8d21ff36127ce6229ac4352527520c64c57cd56L97-R108)
+* Introduced a new `ciot_ble_scn_adv_fifo_slot_t` struct with a `locked` flag for each FIFO slot, and updated the FIFO to use this structure for improved thread-safety. (`include/ciot_ble_scn.h`, `src/common/ciot_ble_scn_base.c`) [[1]](diffhunk://#diff-9cc3ff9f4c60d80c2855302798490b054d719bbcb6706bb5179002e28506ccbaR40-R50) [[2]](diffhunk://#diff-1d56b9dfd453aa5d1584b74b104467528a195ea593194e1b200838f769b93ea2L128-L196)
+* Added new public API functions for the FIFO: `ciot_ble_scn_adv_fifo_pop`, `ciot_ble_scn_adv_fifo_count`, and `ciot_ble_scn_adv_fifo_lost`. These provide safe access and monitoring of the FIFO state. (`include/ciot_ble_scn.h`, `src/common/ciot_ble_scn_base.c`) [[1]](diffhunk://#diff-9cc3ff9f4c60d80c2855302798490b054d719bbcb6706bb5179002e28506ccbaR87-R92) [[2]](diffhunk://#diff-1d56b9dfd453aa5d1584b74b104467528a195ea593194e1b200838f769b93ea2L128-L196)
+* Refactored and improved FIFO push/pop logic to handle contention, overflow, and error reporting, and to track lost advertisements. (`src/common/ciot_ble_scn_base.c`)
+* Changed configuration macros from `CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE` to `CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED` for better feature toggling. (`src/common/ciot_ble_scn_base.c`) [[1]](diffhunk://#diff-1d56b9dfd453aa5d1584b74b104467528a195ea593194e1b200838f769b93ea2R19-R35) [[2]](diffhunk://#diff-1d56b9dfd453aa5d1584b74b104467528a195ea593194e1b200838f769b93ea2L42-R48) [[3]](diffhunk://#diff-1d56b9dfd453aa5d1584b74b104467528a195ea593194e1b200838f769b93ea2L218-R283)
 
-**Core logic updates:**
+**NRF UART Refactor:**
 
-* Modified the `ciot_gpio_base_t` struct to include a new `blink_tick` field for tracking blink phases.
-* Updated the `ciot_gpio_task` function to generate blink signals based on `blink_tick`, supporting the new reverse and slow blinking modes.
-* Enhanced the GPIO state handling to recognize and enable the new blinking modes when setting state. [[1]](diffhunk://#diff-ca74fefe242cdfc7f78a04c8c2ed8bf09d18045410717c57b75e73b859865d36R81-R92) [[2]](diffhunk://#diff-ca74fefe242cdfc7f78a04c8c2ed8bf09d18045410717c57b75e73b859865d36L213-R230)
+* Refactored the NRF UART implementation to use the higher-level `app_uart` driver, removing custom FIFO management and direct use of `nrf_drv_uart`. (`src/nrf/ciot_uart.c`) [[1]](diffhunk://#diff-ffccc2f85616dfd12ec2dbc6a3a71126f30eb2c9fdd873a1d71ee6f6fb46885fL16-R29) [[2]](diffhunk://#diff-ffccc2f85616dfd12ec2dbc6a3a71126f30eb2c9fdd873a1d71ee6f6fb46885fR43-R48) [[3]](diffhunk://#diff-ffccc2f85616dfd12ec2dbc6a3a71126f30eb2c9fdd873a1d71ee6f6fb46885fL74-L121) [[4]](diffhunk://#diff-ffccc2f85616dfd12ec2dbc6a3a71126f30eb2c9fdd873a1d71ee6f6fb46885fL132-R98) [[5]](diffhunk://#diff-ffccc2f85616dfd12ec2dbc6a3a71126f30eb2c9fdd873a1d71ee6f6fb46885fL143-R135)
+* Simplified UART event handling and error reporting by using `app_uart_evt_t` events and global instance management. (`src/nrf/ciot_uart.c`)

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,24,0,1
+#define CIOT_VER 0,25,0,0
 
 #ifndef CIOT_CONFIG_IFACE_CFG_FILENAME_MASK
 #define CIOT_CONFIG_IFACE_CFG_FILENAME_MASK "cfg%d.dat"

--- a/include/ciot_ble_scn.h
+++ b/include/ciot_ble_scn.h
@@ -37,11 +37,17 @@ typedef struct ciot_ble_scn_event_adv_report
 typedef bool (ciot_ble_scn_filter_fn)(ciot_ble_scn_t self, ciot_ble_scn_event_adv_report_t *adv_report, void *args);
 
 #ifdef CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE
+typedef struct ciot_ble_scn_adv_fifo_slot
+{
+    ciot_ble_scn_adv_t adv;
+    volatile bool locked;
+} ciot_ble_scn_adv_fifo_slot_t;
+
 typedef struct ciot_ble_scn_adv_fifo
 {
-    ciot_ble_scn_adv_t list[CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE];
-    int wp;
-    int rp;
+    ciot_ble_scn_adv_fifo_slot_t list[CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE];
+    volatile int wp;
+    volatile int rp;
 } ciot_ble_scn_adv_fifo_t;
 #endif
 
@@ -77,6 +83,12 @@ void ciot_ble_scn_handle_adv_report(ciot_ble_scn_t self, ciot_ble_scn_event_adv_
 ciot_err_t ciot_ble_scn_handle_event(ciot_ble_scn_t self, void *event, void *event_args);
 ciot_err_t ciot_ble_scn_set_filter(ciot_ble_scn_t self, ciot_ble_scn_filter_fn *filter, void *args);
 void ciot_ble_scn_copy_mac(uint8_t destiny[6], uint8_t source[6], bool reverse);
+
+#ifdef CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE
+ciot_err_t ciot_ble_scn_adv_fifo_pop(ciot_ble_scn_t self, ciot_ble_scn_adv_t *adv);
+size_t ciot_ble_scn_adv_fifo_count(ciot_ble_scn_t self);
+size_t ciot_ble_scn_adv_fifo_lost(ciot_ble_scn_t self);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/ciot_ble_scn.h
+++ b/include/ciot_ble_scn.h
@@ -36,7 +36,7 @@ typedef struct ciot_ble_scn_event_adv_report
 
 typedef bool (ciot_ble_scn_filter_fn)(ciot_ble_scn_t self, ciot_ble_scn_event_adv_report_t *adv_report, void *args);
 
-#ifdef CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE
+#if CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED
 typedef struct ciot_ble_scn_adv_fifo_slot
 {
     ciot_ble_scn_adv_t adv;
@@ -64,7 +64,7 @@ typedef struct ciot_ble_scn_base
     ciot_ble_scn_status_t status;
     // ciot_ble_scn_adv_t recv;
     ciot_ble_scn_filter_t filter;
-#ifdef CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE
+#if CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED
     ciot_ble_scn_adv_fifo_t adv_fifo;
 #endif
 } ciot_ble_scn_base_t;

--- a/src/common/ciot_ble_scn_base.c
+++ b/src/common/ciot_ble_scn_base.c
@@ -235,7 +235,6 @@ static ciot_err_t ciot_ble_scn_adv_fifo_push(ciot_ble_scn_base_t *base, ciot_ble
     memcpy(slot->adv.info.mac, adv->mac, sizeof(slot->adv.info.mac));
     slot->adv.info.rssi = adv->rssi;
     slot->adv.payload.size = adv->payload_len;
-
     memcpy(slot->adv.payload.bytes, adv->payload, slot->adv.payload.size);
     
     adv_fifo->wp++;

--- a/src/common/ciot_ble_scn_base.c
+++ b/src/common/ciot_ble_scn_base.c
@@ -16,17 +16,23 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include "app_util_platform.h"
+#include "ciot_log.h"
 #include "ciot_ble_scn.h"
 #include "ciot_config.h"
 
-// static const char *TAG = "ciot_ble_scn";
+#if CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED
+static const char *TAG = "ciot_ble_scn";
+#endif
 
 static ciot_err_t ciot_ble_scn_process_data(ciot_iface_t *iface, ciot_msg_data_t *data);
 static ciot_err_t ciot_ble_scn_get_data(ciot_iface_t *iface, ciot_msg_data_t *msg);
 static ciot_err_t ciot_ble_scn_send_data(ciot_iface_t *iface, uint8_t *data, int size);
 
-#ifdef CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE
+#ifdef CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED
 static ciot_err_t ciot_ble_scn_base_init_fifo(ciot_ble_scn_adv_fifo_t *adv_fifo);
+static ciot_err_t ciot_ble_scn_adv_fifo_push(ciot_ble_scn_base_t *base, ciot_ble_scn_event_adv_report_t *adv);
+// static ciot_err_t ciot_ble_scn_adv_fifo_read(ciot_ble_scn_base_t *base, ciot_ble_scn_adv_t *adv);
 #endif
 
 ciot_err_t ciot_ble_scn_init(ciot_ble_scn_t self)
@@ -39,7 +45,7 @@ ciot_err_t ciot_ble_scn_init(ciot_ble_scn_t self)
     base->iface.send_data = ciot_ble_scn_send_data;
     base->iface.info.type = CIOT_IFACE_TYPE_BLE_SCN;
 
-#if CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE
+#if CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED
     ciot_ble_scn_base_init_fifo(&base->adv_fifo);
 #endif
 
@@ -125,75 +131,131 @@ ciot_err_t ciot_ble_scn_get_status(ciot_ble_scn_t self, ciot_ble_scn_status_t *s
 
 ciot_err_t ciot_ble_scn_base_task(ciot_ble_scn_t self)
 {
-    #if CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE
-    CIOT_ERR_NULL_CHECK(self);
-    ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t*)self;
-    ciot_ble_scn_adv_fifo_t *adv_fifo = &base->adv_fifo;
-	if(base->status.fifo_len > 0)
-	{
-		if(adv_fifo->list[adv_fifo->rp].info.rssi != 0)
-		{
-			// ciot_iface_event_t event = {0};
-            // event.type = CIOT_IFACE_EVENT_DATA;
-            // event.data = (uint8_t*)&adv_fifo->list[adv_fifo->rp];
-            ciot_iface_send_event_data(&base->iface,
-                                      CIOT_EVENT_TYPE_DATA,
-                                      (uint8_t*)&adv_fifo->list[adv_fifo->rp],
-                                      sizeof(ciot_ble_scn_adv_t));
-			adv_fifo->list[adv_fifo->rp].info.rssi = 0;
-			adv_fifo->rp++;
-			base->status.fifo_len--;
-			if(adv_fifo->rp >= CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE)
-			{
-				adv_fifo->rp = 0;
-			}
-		}
-        else
-        {
-            base->status.err_code = CIOT_ERR_FIFO_READ;
-            adv_fifo->rp++;
-        }
-	}
-#endif
     return CIOT_ERR_OK;
 }
 
 void ciot_ble_scn_handle_adv_report(ciot_ble_scn_t self, ciot_ble_scn_event_adv_report_t *adv)
 {
-    ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t*)self;
-#ifdef CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE
-    ciot_ble_scn_adv_fifo_t *adv_fifo = &base->adv_fifo;
-    if(adv_fifo->list[adv_fifo->wp].info.rssi == 0)
-    {
-        adv_fifo->list[adv_fifo->wp] = *adv;
-        adv_fifo->wp++;
-        base->status.fifo_len++;
-        if(base->status.fifo_len > base->status.fifo_max)
-        {
-            base->status.fifo_max = base->status.fifo_len;
-        }
-        if(adv_fifo->wp == CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE)
-        {
-            adv_fifo->wp = 0;
-        }
-    }
-    else
-    {
-        adv_fifo->rp = adv_fifo->wp;
-        base->status.advs_losted++;
-        if(base->status.fifo_len == 0)
-        {
-            base->status.err_code = CIOT_ERR_INVALID_SIZE;
-            for (size_t i = 0; i < BOARD_BLE_SCN_ADV_FIFO_SIZE; i++)
-            {
-                if(adv_fifo->list[i].info.rssi != 0) base->status.fifo_len++;
-            }
-        }
-    }
+#ifdef CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED
+    ciot_ble_scn_adv_fifo_push((ciot_ble_scn_base_t *)self, adv);
 #else
+    ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t*)self;
     ciot_iface_send_event_data(&base->iface, CIOT_EVENT_TYPE_DATA, (uint8_t*)adv, sizeof(*adv));
 #endif
 }
+
+#ifdef CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED
+ciot_err_t ciot_ble_scn_adv_fifo_pop(ciot_ble_scn_t self, ciot_ble_scn_adv_t *adv)
+{
+    CIOT_ERR_NULL_CHECK(self);
+    CIOT_ERR_NULL_CHECK(adv);
+
+    ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t *)self;
+    ciot_ble_scn_adv_fifo_t *adv_fifo = &base->adv_fifo;
+    ciot_ble_scn_adv_fifo_slot_t *slot = NULL;
+
+    if (base->status.fifo_len == 0)
+    {
+        base->status.err_code = CIOT_ERR_NOT_FOUND;
+        return CIOT_ERR_NOT_FOUND;
+    }
+
+    slot = &adv_fifo->list[adv_fifo->rp];
+    if (slot->locked)
+    {
+        base->status.err_code = CIOT_ERR_BUSY;
+        CIOT_LOGE(TAG, "ADV FIFO pop contention (slot=%d)", adv_fifo->rp);
+        return CIOT_ERR_BUSY;
+    }
+
+    slot->locked = true;
+    *adv = slot->adv;                   /// copy slot->adv to adv
+    slot->adv.has_info = false;
+    slot->locked = false;
+   
+    if (base->status.fifo_len > base->status.fifo_max)
+    {
+        base->status.fifo_max = base->status.fifo_len;
+    }
+    adv_fifo->rp++;
+    base->status.fifo_len--;
+    if (adv_fifo->rp >= CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE)
+    {
+        adv_fifo->rp = 0;
+    }
+
+    return CIOT_ERR_OK;
+}
+
+size_t ciot_ble_scn_adv_fifo_count(ciot_ble_scn_t self)
+{
+    if (self == NULL)
+    {
+        return 0;
+    }
+
+    ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t *)self;
+    return base->status.fifo_len;
+}
+
+size_t ciot_ble_scn_adv_fifo_lost(ciot_ble_scn_t self)
+{
+    if (self == NULL)
+    {
+        return 0;
+    }
+
+    ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t *)self;
+    return base->status.advs_losted;
+}
+
+static ciot_err_t ciot_ble_scn_adv_fifo_push(ciot_ble_scn_base_t *base, ciot_ble_scn_event_adv_report_t *adv)
+{
+    ciot_ble_scn_adv_fifo_t *adv_fifo = &base->adv_fifo;
+    ciot_ble_scn_adv_fifo_slot_t *slot = NULL;
+
+    if (base->status.fifo_len >= CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE)
+    {
+        base->status.advs_losted++;
+        base->status.err_code = CIOT_ERR_NO_MEMORY;
+        CIOT_LOGE(TAG, "ADV FIFO full (wp=%d rp=%d len=%lu)", adv_fifo->wp, adv_fifo->rp, (unsigned long)base->status.fifo_len);
+        return CIOT_ERR_NO_MEMORY;
+    }
+
+    slot = &adv_fifo->list[adv_fifo->wp];
+    if (slot->locked)
+    {
+        base->status.advs_losted++;
+        base->status.err_code = CIOT_ERR_BUSY;
+        CIOT_LOGE(TAG, "ADV FIFO push contention (slot=%d)", adv_fifo->wp);
+        return CIOT_ERR_BUSY;
+    }
+
+    slot->locked = true;
+    slot->adv.has_info = true;
+    memcpy(slot->adv.info.mac, adv->mac, sizeof(slot->adv.info.mac));
+    slot->adv.info.rssi = adv->rssi;
+    slot->adv.payload.size = adv->payload_len;
+
+    memcpy(slot->adv.payload.bytes, adv->payload, slot->adv.payload.size);
+    
+    adv_fifo->wp++;
+    base->status.fifo_len++;
+    
+    if (adv_fifo->wp == CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE)
+    {
+        adv_fifo->wp = 0;
+    }
+    
+    slot->locked = false;
+    return CIOT_ERR_OK;
+}
+
+// static ciot_err_t ciot_ble_scn_adv_fifo_read(ciot_ble_scn_base_t *base, ciot_ble_scn_adv_t *adv)
+// {
+    
+// }
+#endif
 
 ciot_err_t ciot_ble_scn_set_filter(ciot_ble_scn_t self, ciot_ble_scn_filter_fn *filter, void *args)
 {
@@ -215,17 +277,10 @@ void ciot_ble_scn_copy_mac(uint8_t destiny[6], uint8_t source[6], bool reverse)
     }
 }
 
-#if CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE
+#if CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED
 static ciot_err_t ciot_ble_scn_base_init_fifo(ciot_ble_scn_adv_fifo_t *adv_fifo)
 {
-    // for (size_t i = 0; i < CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE; i++)
-    // {
-    //     ciot__ble_scn_adv__init(&adv_fifo->list[i]);
-    //     ciot__ble_scn_adv_info__init(&adv_fifo->data.infos[i]);
-    //     adv_fifo->list[i].info = &adv_fifo->data.infos[i];
-    //     adv_fifo->list[i].info->mac.data = adv_fifo->data.macs[i];
-    //     adv_fifo->list[i].payload.data = adv_fifo->data.advs[i];
-    // }
+    memset(adv_fifo, 0, sizeof(*adv_fifo));
     return CIOT_ERR_OK;
 }
 #endif

--- a/src/common/ciot_ble_scn_base.c
+++ b/src/common/ciot_ble_scn_base.c
@@ -32,7 +32,6 @@ static ciot_err_t ciot_ble_scn_send_data(ciot_iface_t *iface, uint8_t *data, int
 #ifdef CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED
 static ciot_err_t ciot_ble_scn_base_init_fifo(ciot_ble_scn_adv_fifo_t *adv_fifo);
 static ciot_err_t ciot_ble_scn_adv_fifo_push(ciot_ble_scn_base_t *base, ciot_ble_scn_event_adv_report_t *adv);
-// static ciot_err_t ciot_ble_scn_adv_fifo_read(ciot_ble_scn_base_t *base, ciot_ble_scn_adv_t *adv);
 #endif
 
 ciot_err_t ciot_ble_scn_init(ciot_ble_scn_t self)
@@ -251,10 +250,6 @@ static ciot_err_t ciot_ble_scn_adv_fifo_push(ciot_ble_scn_base_t *base, ciot_ble
     return CIOT_ERR_OK;
 }
 
-// static ciot_err_t ciot_ble_scn_adv_fifo_read(ciot_ble_scn_base_t *base, ciot_ble_scn_adv_t *adv)
-// {
-    
-// }
 #endif
 
 ciot_err_t ciot_ble_scn_set_filter(ciot_ble_scn_t self, ciot_ble_scn_filter_fn *filter, void *args)
@@ -264,8 +259,6 @@ ciot_err_t ciot_ble_scn_set_filter(ciot_ble_scn_t self, ciot_ble_scn_filter_fn *
     ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t*)self;
     base->filter.handler = filter;
     base->filter.args = args;
-    // base->filter.handler = filter;
-    // base->filter.args = args;
     return CIOT_ERR_OK;
 }
 

--- a/src/common/ciot_ble_scn_base.c
+++ b/src/common/ciot_ble_scn_base.c
@@ -29,7 +29,7 @@ static ciot_err_t ciot_ble_scn_process_data(ciot_iface_t *iface, ciot_msg_data_t
 static ciot_err_t ciot_ble_scn_get_data(ciot_iface_t *iface, ciot_msg_data_t *msg);
 static ciot_err_t ciot_ble_scn_send_data(ciot_iface_t *iface, uint8_t *data, int size);
 
-#ifdef CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED
+#if CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED
 static ciot_err_t ciot_ble_scn_base_init_fifo(ciot_ble_scn_adv_fifo_t *adv_fifo);
 static ciot_err_t ciot_ble_scn_adv_fifo_push(ciot_ble_scn_base_t *base, ciot_ble_scn_event_adv_report_t *adv);
 #endif
@@ -135,7 +135,7 @@ ciot_err_t ciot_ble_scn_base_task(ciot_ble_scn_t self)
 
 void ciot_ble_scn_handle_adv_report(ciot_ble_scn_t self, ciot_ble_scn_event_adv_report_t *adv)
 {
-#ifdef CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED
+#if CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED
     ciot_ble_scn_adv_fifo_push((ciot_ble_scn_base_t *)self, adv);
 #else
     ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t*)self;
@@ -143,7 +143,7 @@ void ciot_ble_scn_handle_adv_report(ciot_ble_scn_t self, ciot_ble_scn_event_adv_
 #endif
 }
 
-#ifdef CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED
+#if CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED
 ciot_err_t ciot_ble_scn_adv_fifo_pop(ciot_ble_scn_t self, ciot_ble_scn_adv_t *adv)
 {
     CIOT_ERR_NULL_CHECK(self);

--- a/src/common/ciot_ble_scn_base.c
+++ b/src/common/ciot_ble_scn_base.c
@@ -1,15 +1,14 @@
 /**
  * @file ciot_ble_scn_base.c
  * @author your name (you@domain.com)
- * @brief 
+ * @brief
  * @version 0.1
  * @date 2024-06-07
- * 
+ *
  * @copyright Copyright (c) 2024
- * 
+ *
  */
 
- 
 #include "ciot_config.h"
 
 #if CIOT_CONFIG_FEATURE_BLE_SCN == 1
@@ -36,7 +35,7 @@ static ciot_err_t ciot_ble_scn_adv_fifo_push(ciot_ble_scn_base_t *base, ciot_ble
 
 ciot_err_t ciot_ble_scn_init(ciot_ble_scn_t self)
 {
-    ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t*)self;
+    ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t *)self;
 
     base->iface.ptr = self;
     base->iface.process_data = ciot_ble_scn_process_data;
@@ -114,7 +113,7 @@ ciot_err_t ciot_ble_scn_get_cfg(ciot_ble_scn_t self, ciot_ble_scn_cfg_t *cfg)
 {
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(cfg);
-    ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t*)self;
+    ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t *)self;
     *cfg = base->cfg;
     return CIOT_ERR_OK;
 }
@@ -123,7 +122,7 @@ ciot_err_t ciot_ble_scn_get_status(ciot_ble_scn_t self, ciot_ble_scn_status_t *s
 {
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(status);
-    ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t*)self;
+    ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t *)self;
     *status = base->status;
     return CIOT_ERR_OK;
 }
@@ -138,8 +137,8 @@ void ciot_ble_scn_handle_adv_report(ciot_ble_scn_t self, ciot_ble_scn_event_adv_
 #if CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED
     ciot_ble_scn_adv_fifo_push((ciot_ble_scn_base_t *)self, adv);
 #else
-    ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t*)self;
-    ciot_iface_send_event_data(&base->iface, CIOT_EVENT_TYPE_DATA, (uint8_t*)adv, sizeof(*adv));
+    ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t *)self;
+    ciot_iface_send_event_data(&base->iface, CIOT_EVENT_TYPE_DATA, (uint8_t *)adv, sizeof(*adv));
 #endif
 }
 
@@ -168,10 +167,10 @@ ciot_err_t ciot_ble_scn_adv_fifo_pop(ciot_ble_scn_t self, ciot_ble_scn_adv_t *ad
     }
 
     slot->locked = true;
-    *adv = slot->adv;                   /// copy slot->adv to adv
+    *adv = slot->adv; /// copy slot->adv to adv
     slot->adv.has_info = false;
     slot->locked = false;
-   
+
     if (base->status.fifo_len > base->status.fifo_max)
     {
         base->status.fifo_max = base->status.fifo_len;
@@ -246,15 +245,15 @@ static ciot_err_t ciot_ble_scn_adv_fifo_push(ciot_ble_scn_base_t *base, ciot_ble
     }
     slot->adv.payload.size = adv->payload_len;
     memcpy(slot->adv.payload.bytes, adv->payload, slot->adv.payload.size);
-    
+
     adv_fifo->wp++;
     base->status.fifo_len++;
-    
+
     if (adv_fifo->wp == CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE)
     {
         adv_fifo->wp = 0;
     }
-    
+
     slot->locked = false;
     return CIOT_ERR_OK;
 }
@@ -264,8 +263,8 @@ static ciot_err_t ciot_ble_scn_adv_fifo_push(ciot_ble_scn_base_t *base, ciot_ble
 ciot_err_t ciot_ble_scn_set_filter(ciot_ble_scn_t self, ciot_ble_scn_filter_fn *filter, void *args)
 {
     CIOT_ERR_NULL_CHECK(self);
-	CIOT_ERR_NULL_CHECK(filter);
-    ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t*)self;
+    CIOT_ERR_NULL_CHECK(filter);
+    ciot_ble_scn_base_t *base = (ciot_ble_scn_base_t *)self;
     base->filter.handler = filter;
     base->filter.args = args;
     return CIOT_ERR_OK;
@@ -287,4 +286,4 @@ static ciot_err_t ciot_ble_scn_base_init_fifo(ciot_ble_scn_adv_fifo_t *adv_fifo)
 }
 #endif
 
-#endif  //!CIOT_CONFIG_FEATURE_BLE_SCN == 1
+#endif //! CIOT_CONFIG_FEATURE_BLE_SCN == 1

--- a/src/common/ciot_ble_scn_base.c
+++ b/src/common/ciot_ble_scn_base.c
@@ -234,6 +234,16 @@ static ciot_err_t ciot_ble_scn_adv_fifo_push(ciot_ble_scn_base_t *base, ciot_ble
     slot->adv.has_info = true;
     memcpy(slot->adv.info.mac, adv->mac, sizeof(slot->adv.info.mac));
     slot->adv.info.rssi = adv->rssi;
+
+    const size_t max_payload = sizeof(slot->adv.payload.bytes);
+    if (adv->payload_len > max_payload)
+    {
+        slot->locked = false;
+        base->status.advs_losted++;
+        base->status.err_code = CIOT_ERR_INVALID_SIZE;
+        CIOT_LOGE(TAG, "ADV payload too large (%u > %lu)", adv->payload_len, (unsigned long)max_payload);
+        return CIOT_ERR_INVALID_SIZE;
+    }
     slot->adv.payload.size = adv->payload_len;
     memcpy(slot->adv.payload.bytes, adv->payload, slot->adv.payload.size);
     

--- a/src/nrf/ciot_uart.c
+++ b/src/nrf/ciot_uart.c
@@ -51,7 +51,7 @@ ciot_err_t ciot_uart_start(ciot_uart_t self, ciot_uart_cfg_t *cfg)
     {
         return CIOT_ERR_INVALID_ARG;
     }
-    
+
     if (_self != NULL && _self != self)
     {
         return CIOT_ERR_INVALID_STATE;
@@ -158,6 +158,11 @@ ciot_err_t ciot_uart_task(ciot_uart_t self)
 
 static void ciot_uart_event_handler(app_uart_evt_t *p_event)
 {
+    if (_self == NULL)
+    {
+        return;
+    }
+
     ciot_uart_t self = _self;
     ciot_uart_base_t *base = &self->base;
     uint8_t byte;

--- a/src/nrf/ciot_uart.c
+++ b/src/nrf/ciot_uart.c
@@ -11,7 +11,7 @@
 
 #include "ciot_config.h"
 
-#if CIOT_CONFIG_FEATURE_UART == 1 == 0 && defined(CIOT_PLATFORM_NRF)
+#if CIOT_CONFIG_FEATURE_UART == 1 && defined(CIOT_PLATFORM_NRF)
 
 #include "app_uart.h"
 #include "ciot_uart.h"

--- a/src/nrf/ciot_uart.c
+++ b/src/nrf/ciot_uart.c
@@ -1,12 +1,12 @@
 /**
  * @file ciot_uart.c
  * @author your name (you@domain.com)
- * @brief 
+ * @brief
  * @version 0.1
  * @date 2024-06-07
- * 
+ *
  * @copyright Copyright (c) 2024
- * 
+ *
  */
 
 #include "ciot_config.h"
@@ -33,7 +33,7 @@ static const char *TAG = "ciot_uart";
 
 static ciot_uart_t _self = NULL;
 
-static void ciot_uart_event_handler(app_uart_evt_t * p_event);
+static void ciot_uart_event_handler(app_uart_evt_t *p_event);
 
 ciot_uart_t ciot_uart_new(void *handle)
 {
@@ -60,37 +60,36 @@ ciot_err_t ciot_uart_start(ciot_uart_t self, ciot_uart_cfg_t *cfg)
     _self = self;
     ciot_uart_base_t *base = &self->base;
 
-    if(base->status.state == CIOT_UART_STATE_STARTED &&
-       base->cfg.num == cfg->num)
+    if (base->status.state == CIOT_UART_STATE_STARTED &&
+        base->cfg.num == cfg->num)
     {
         return CIOT_ERR_OK;
     }
 
-    if(cfg->has_gpio == false)
+    if (cfg->has_gpio == false)
     {
         cfg->gpio = base->cfg.gpio;
     }
     base->cfg = *cfg;
 
     const app_uart_comm_params_t comm_params =
-    {
-        .rx_pin_no = base->cfg.gpio.rx,
-        .tx_pin_no = base->cfg.gpio.tx,
-        .rts_pin_no = base->cfg.gpio.rts,
-        .cts_pin_no = base->cfg.gpio.cts,
-        .flow_control = base->cfg.flow_control ? APP_UART_FLOW_CONTROL_ENABLED : APP_UART_FLOW_CONTROL_DISABLED,
-        .use_parity = base->cfg.parity ? true : false,
-        .baud_rate = base->cfg.baud_rate
-    };
+        {
+            .rx_pin_no = base->cfg.gpio.rx,
+            .tx_pin_no = base->cfg.gpio.tx,
+            .rts_pin_no = base->cfg.gpio.rts,
+            .cts_pin_no = base->cfg.gpio.cts,
+            .flow_control = base->cfg.flow_control ? APP_UART_FLOW_CONTROL_ENABLED : APP_UART_FLOW_CONTROL_DISABLED,
+            .use_parity = base->cfg.parity ? true : false,
+            .baud_rate = base->cfg.baud_rate};
 
     uint32_t err_code;
 
     APP_UART_FIFO_INIT(&comm_params,
-                         CIOT_CONFIG_UART_RX_BUF_SIZE,
-                         CIOT_CONFIG_UART_TX_BUF_SIZE,
-                         ciot_uart_event_handler,
-                         APP_IRQ_PRIORITY_LOWEST,
-                         err_code);
+                       CIOT_CONFIG_UART_RX_BUF_SIZE,
+                       CIOT_CONFIG_UART_TX_BUF_SIZE,
+                       ciot_uart_event_handler,
+                       APP_IRQ_PRIORITY_LOWEST,
+                       err_code);
 
     APP_ERROR_CHECK(err_code);
 
@@ -116,10 +115,10 @@ ciot_err_t ciot_uart_send_bytes(ciot_uart_t self, uint8_t *bytes, int size)
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(bytes);
 
-    for(int i = 0; i < size; i++)
+    for (int i = 0; i < size; i++)
     {
         uint32_t err_code = app_uart_put(bytes[i]);
-        if(err_code != NRF_SUCCESS)
+        if (err_code != NRF_SUCCESS)
         {
             return CIOT_ERR_FAIL;
         }
@@ -132,12 +131,12 @@ ciot_err_t ciot_uart_read_bytes(ciot_uart_t self, uint8_t *bytes, int size)
 {
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(bytes);
-    
+
     for (int i = 0; i < size; i++)
     {
         uint8_t byte;
         uint32_t err_code = app_uart_get(&byte);
-        if(err_code != NRF_SUCCESS)
+        if (err_code != NRF_SUCCESS)
         {
             return CIOT_ERR_FAIL;
         }
@@ -157,7 +156,7 @@ ciot_err_t ciot_uart_task(ciot_uart_t self)
     return CIOT_ERR_OK;
 }
 
-static void ciot_uart_event_handler(app_uart_evt_t * p_event)
+static void ciot_uart_event_handler(app_uart_evt_t *p_event)
 {
     ciot_uart_t self = _self;
     ciot_uart_base_t *base = &self->base;
@@ -165,22 +164,22 @@ static void ciot_uart_event_handler(app_uart_evt_t * p_event)
 
     switch (p_event->evt_type)
     {
-        case APP_UART_DATA_READY:
-            if(app_uart_get(&byte) == NRF_SUCCESS)
-            {
-                ciot_iface_process_data(&base->iface, &byte, 1, CIOT_EVENT_TYPE_MSG);
-            }
-            break;
-        case APP_UART_COMMUNICATION_ERROR:
-            CIOT_LOGE(TAG, "UART communication error: %d", p_event->data.error_communication);
-            base->status.error = CIOT_ERR_FAIL;
-            break;
-        case APP_UART_FIFO_ERROR:
-            CIOT_LOGE(TAG, "UART FIFO error: %d", p_event->data.error_code);
-            base->status.error = CIOT_ERR_OVERFLOW;
-            break;
-        default:
-            break;
+    case APP_UART_DATA_READY:
+        if (app_uart_get(&byte) == NRF_SUCCESS)
+        {
+            ciot_iface_process_data(&base->iface, &byte, 1, CIOT_EVENT_TYPE_MSG);
+        }
+        break;
+    case APP_UART_COMMUNICATION_ERROR:
+        CIOT_LOGE(TAG, "UART communication error: %d", p_event->data.error_communication);
+        base->status.error = CIOT_ERR_FAIL;
+        break;
+    case APP_UART_FIFO_ERROR:
+        CIOT_LOGE(TAG, "UART FIFO error: %d", p_event->data.error_code);
+        base->status.error = CIOT_ERR_OVERFLOW;
+        break;
+    default:
+        break;
     }
 }
 

--- a/src/nrf/ciot_uart.c
+++ b/src/nrf/ciot_uart.c
@@ -11,39 +11,22 @@
 
 #include "ciot_config.h"
 
-#if CIOT_CONFIG_FEATURE_UART == 1 && defined(CIOT_PLATFORM_NRF)
+#if CIOT_CONFIG_FEATURE_UART == 1 == 0 && defined(CIOT_PLATFORM_NRF)
 
-#include <stdlib.h>
-#include "app_fifo.h"
-#include "app_util_platform.h"
-#include "nrf_drv_uart.h"
-#include "sdk_config.h"
-#include "sdk_macros.h"
+#include "app_uart.h"
 #include "ciot_uart.h"
 #include "ciot_err.h"
-
-#define UART_PIN_DISCONNECTED 0xFFFFFFFF
-
-#ifndef CIOT_CONFIG_UART_TX_BUF_SIZE
-#define CIOT_CONFIG_UART_TX_BUF_SIZE 256
-#endif
-
-typedef struct ciot_uart_fifo
-{
-    app_fifo_t tx;
-    uint8_t tx_buf[CIOT_CONFIG_UART_TX_BUF_SIZE];
-} ciot_uart_fifo_t;
 
 struct ciot_uart
 {
     ciot_uart_base_t base;
-    nrf_drv_uart_t handle;
-    ciot_uart_fifo_t fifo;
-    uint8_t rx_byte[1];
-    uint8_t tx_byte[1];
 };
 
-static void ciot_uart_event_handler(nrf_drv_uart_event_t *event, void *context);
+static const char *TAG = "ciot_uart";
+
+static ciot_uart_t _self = NULL;
+
+static void ciot_uart_event_handler(app_uart_evt_t * p_event);
 
 ciot_uart_t ciot_uart_new(void *handle)
 {
@@ -57,6 +40,12 @@ ciot_err_t ciot_uart_start(ciot_uart_t self, ciot_uart_cfg_t *cfg)
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(cfg);
 
+    if(_self != NULL)
+    {
+        return CIOT_ERR_INVALID_STATE;
+    }
+
+    _self = self;
     ciot_uart_base_t *base = &self->base;
 
     if(base->status.state == CIOT_UART_STATE_STARTED &&
@@ -71,54 +60,28 @@ ciot_err_t ciot_uart_start(ciot_uart_t self, ciot_uart_cfg_t *cfg)
     }
     base->cfg = *cfg;
 
-    uint32_t err_code = app_fifo_init(&self->fifo.tx, self->fifo.tx_buf, CIOT_CONFIG_UART_TX_BUF_SIZE);
-    VERIFY_SUCCESS(err_code);
-
-    nrf_drv_uart_config_t config = NRF_DRV_UART_DEFAULT_CONFIG;
-    config.baudrate = (nrf_uart_baudrate_t)base->cfg.baud_rate;
-    config.hwfc = base->cfg.flow_control;
-    config.interrupt_priority = APP_IRQ_PRIORITY_LOWEST;
-    config.parity = base->cfg.parity;
-    config.pselcts = base->cfg.gpio.cts;
-    config.pselrts = base->cfg.gpio.rts;
-    config.pselrxd = base->cfg.gpio.rx;
-    config.pseltxd = base->cfg.gpio.tx;
-    config.p_context = self;
-
-    switch (cfg->num)
+    const app_uart_comm_params_t comm_params =
     {
-#if UART0_ENABLED
-    case 0:
-        {
-            static nrf_drv_uart_t uart_inst0 = NRF_DRV_UART_INSTANCE(0);
-            self->handle = uart_inst0;
-            break;
-        }
-#endif
-#if UART1_ENABLED
-    case 1:
-        {
-            static nrf_drv_uart_t uart_inst1 = NRF_DRV_UART_INSTANCE(1);
-            self->handle = uart_inst1;
-            break;
-        }
-#endif
-    default:
-        return CIOT_ERR_INVALID_ARG;
-    }
+        .rx_pin_no = base->cfg.gpio.rx,
+        .tx_pin_no = base->cfg.gpio.tx,
+        .rts_pin_no = base->cfg.gpio.rts,
+        .cts_pin_no = base->cfg.gpio.cts,
+        .flow_control = base->cfg.flow_control ? APP_UART_FLOW_CONTROL_ENABLED : APP_UART_FLOW_CONTROL_DISABLED,
+        .use_parity = base->cfg.parity ? true : false,
+        .baud_rate = base->cfg.baud_rate
+    };
 
-    err_code = nrf_drv_uart_init(&self->handle, &config, ciot_uart_event_handler);
-    VERIFY_SUCCESS(err_code);
+    uint32_t err_code;
 
-    if (base->cfg.gpio.rx != UART_PIN_DISCONNECTED)
-    {
-        nrf_drv_uart_rx(&self->handle, self->rx_byte, 1);
-    }
+    APP_UART_FIFO_INIT(&comm_params,
+                         CIOT_CONFIG_UART_RX_BUF_SIZE,
+                         CIOT_CONFIG_UART_TX_BUF_SIZE,
+                         ciot_uart_event_handler,
+                         APP_IRQ_PRIORITY_LOWEST,
+                         err_code);
 
-    // ciot_event_t event = {0};
-    // event.type = CIOT_IFACE_EVENT_STARTED;
-    // event.msg = ciot_msg_get(CIOT__MSG_TYPE__MSG_TYPE_STATUS, &base->iface);
-    // ciot_iface_send_event(&base->iface, &event);
+    APP_ERROR_CHECK(err_code);
+
     ciot_iface_send_event_type(&base->iface, CIOT_EVENT_TYPE_STARTED);
 
     base->status.state = CIOT_UART_STATE_STARTED;
@@ -129,9 +92,10 @@ ciot_err_t ciot_uart_start(ciot_uart_t self, ciot_uart_cfg_t *cfg)
 ciot_err_t ciot_uart_stop(ciot_uart_t self)
 {
     CIOT_ERR_NULL_CHECK(self);
-    nrf_drv_uart_uninit(&self->handle);
+    app_uart_close();
     self->base.status.state = CIOT_UART_STATE_CLOSED;
     ciot_iface_send_event_type(&self->base.iface, CIOT_EVENT_TYPE_STOPPED);
+    _self = NULL;
     return CIOT_ERR_OK;
 }
 
@@ -139,38 +103,36 @@ ciot_err_t ciot_uart_send_bytes(ciot_uart_t self, uint8_t *bytes, int size)
 {
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(bytes);
-    
-    uint32_t err_code;
-    uint32_t len = 0;
 
-    app_fifo_write(&self->fifo.tx, NULL, &len);
-    err_code = len < size ? CIOT_UART_ERROR_FIFO_OVERFLOW : CIOT_ERR_OK;
-    if(err_code == CIOT_ERR_OK)
+    for(int i = 0; i < size; i++)
     {
-        len = size;
-        err_code = app_fifo_write(&self->fifo.tx, bytes, &len);
-    }
-    else if(self->base.status.state == CIOT_UART_STATE_STARTED)
-    {
-        self->base.status.error = self->base.status.error;
-    }
-    if(!nrf_drv_uart_tx_in_progress(&self->handle))
-    {
-        if(app_fifo_get(&self->fifo.tx, self->tx_byte) == NRF_SUCCESS) 
+        uint32_t err_code = app_uart_put(bytes[i]);
+        if(err_code != NRF_SUCCESS)
         {
-            err_code = nrf_drv_uart_tx(&self->handle, self->tx_byte, 1);
+            return CIOT_ERR_FAIL;
         }
     }
 
-    return err_code;
+    return CIOT_ERR_OK;
 }
 
 ciot_err_t ciot_uart_read_bytes(ciot_uart_t self, uint8_t *bytes, int size)
 {
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(bytes);
-    ret_code_t code = nrf_drv_uart_rx(&self->handle, bytes,  size);
-    return code == NRF_SUCCESS ? size : CIOT_ERR_FAIL;
+    
+    for (int i = 0; i < size; i++)
+    {
+        uint8_t byte;
+        uint32_t err_code = app_uart_get(&byte);
+        if(err_code != NRF_SUCCESS)
+        {
+            return CIOT_ERR_FAIL;
+        }
+        bytes[i] = byte;
+    }
+
+    return CIOT_ERR_OK;
 }
 
 size_t ciot_uart_available(ciot_uart_t self)
@@ -180,39 +142,33 @@ size_t ciot_uart_available(ciot_uart_t self)
 
 ciot_err_t ciot_uart_task(ciot_uart_t self)
 {
-    return CIOT_ERR_NOT_IMPLEMENTED;
+    return CIOT_ERR_OK;
 }
 
-static void ciot_uart_event_handler(nrf_drv_uart_event_t *event, void *args)
+static void ciot_uart_event_handler(app_uart_evt_t * p_event)
 {
-    ciot_uart_t self = (ciot_uart_t)args;
+    ciot_uart_t self = _self;
     ciot_uart_base_t *base = &self->base;
+    uint8_t byte;
 
-    switch (event->type)
+    switch (p_event->evt_type)
     {
-        case NRF_DRV_UART_EVT_TX_DONE:
-            if (app_fifo_get(&self->fifo.tx, self->tx_byte) == NRF_SUCCESS)
+        case APP_UART_DATA_READY:
+            if(app_uart_get(&byte) == NRF_SUCCESS)
             {
-                nrf_drv_uart_tx(&self->handle, self->tx_byte, 1);
+                ciot_iface_process_data(&base->iface, &byte, 1, CIOT_EVENT_TYPE_MSG);
             }
             break;
-        case NRF_DRV_UART_EVT_RX_DONE:
-            if(event->data.rxtx.bytes == 0)
-            {
-                nrf_drv_uart_rx(&self->handle, self->rx_byte, 1);
-                break;
-            }
-            ciot_err_t err = ciot_iface_process_data(&self->base.iface, event->data.rxtx.p_data, event->data.rxtx.bytes, CIOT_EVENT_TYPE_MSG);
-            if(err != CIOT_ERR_OK)
-            {
-                base->status.error = err;
-            }
-            nrf_drv_uart_rx(&self->handle, self->rx_byte, 1);
+        case APP_UART_COMMUNICATION_ERROR:
+            CIOT_LOGE(TAG, "UART communication error: %d", p_event->data.error_communication);
+            base->status.error = CIOT_ERR_FAIL;
             break;
-        case NRF_DRV_UART_EVT_ERROR:
-            nrf_drv_uart_rx(&self->handle, self->rx_byte, 1);
+        case APP_UART_FIFO_ERROR:
+            CIOT_LOGE(TAG, "UART FIFO error: %d", p_event->data.error_code);
+            base->status.error = CIOT_ERR_OVERFLOW;
             break;
-        break;
+        default:
+            break;
     }
 }
 

--- a/src/nrf/ciot_uart.c
+++ b/src/nrf/ciot_uart.c
@@ -47,7 +47,12 @@ ciot_err_t ciot_uart_start(ciot_uart_t self, ciot_uart_cfg_t *cfg)
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(cfg);
 
-    if(_self != NULL)
+    if (cfg->num != 0)
+    {
+        return CIOT_ERR_INVALID_ARG;
+    }
+    
+    if (_self != NULL && _self != self)
     {
         return CIOT_ERR_INVALID_STATE;
     }

--- a/src/nrf/ciot_uart.c
+++ b/src/nrf/ciot_uart.c
@@ -17,12 +17,12 @@
 #include "ciot_uart.h"
 #include "ciot_err.h"
 
- #ifndef CIOT_CONFIG_UART_RX_BUF_SIZE
- #define CIOT_CONFIG_UART_RX_BUF_SIZE 256
- #endif
- #ifndef CIOT_CONFIG_UART_TX_BUF_SIZE
- #define CIOT_CONFIG_UART_TX_BUF_SIZE 256
- #endif
+#ifndef CIOT_CONFIG_UART_RX_BUF_SIZE
+#define CIOT_CONFIG_UART_RX_BUF_SIZE 256
+#endif
+#ifndef CIOT_CONFIG_UART_TX_BUF_SIZE
+#define CIOT_CONFIG_UART_TX_BUF_SIZE 256
+#endif
 
 struct ciot_uart
 {

--- a/src/nrf/ciot_uart.c
+++ b/src/nrf/ciot_uart.c
@@ -17,6 +17,13 @@
 #include "ciot_uart.h"
 #include "ciot_err.h"
 
+ #ifndef CIOT_CONFIG_UART_RX_BUF_SIZE
+ #define CIOT_CONFIG_UART_RX_BUF_SIZE 256
+ #endif
+ #ifndef CIOT_CONFIG_UART_TX_BUF_SIZE
+ #define CIOT_CONFIG_UART_TX_BUF_SIZE 256
+ #endif
+
 struct ciot_uart
 {
     ciot_uart_base_t base;


### PR DESCRIPTION
This pull request introduces significant improvements to the BLE scanner (BLE SCN) advertisement FIFO handling and refactors the UART implementation for the NRF platform to use the `app_uart` driver instead of the lower-level `nrf_drv_uart` and custom FIFO logic. The BLE SCN changes add thread-safety and reliability to advertisement queueing, while the NRF UART changes simplify the driver code and improve maintainability.

**BLE SCN Advertisement FIFO Improvements:**

* Introduced a new `ciot_ble_scn_adv_fifo_slot_t` struct with a `locked` flag for each FIFO slot, and updated the FIFO to use this structure for improved thread-safety. (`include/ciot_ble_scn.h`, `src/common/ciot_ble_scn_base.c`) [[1]](diffhunk://#diff-9cc3ff9f4c60d80c2855302798490b054d719bbcb6706bb5179002e28506ccbaR40-R50) [[2]](diffhunk://#diff-1d56b9dfd453aa5d1584b74b104467528a195ea593194e1b200838f769b93ea2L128-L196)
* Added new public API functions for the FIFO: `ciot_ble_scn_adv_fifo_pop`, `ciot_ble_scn_adv_fifo_count`, and `ciot_ble_scn_adv_fifo_lost`. These provide safe access and monitoring of the FIFO state. (`include/ciot_ble_scn.h`, `src/common/ciot_ble_scn_base.c`) [[1]](diffhunk://#diff-9cc3ff9f4c60d80c2855302798490b054d719bbcb6706bb5179002e28506ccbaR87-R92) [[2]](diffhunk://#diff-1d56b9dfd453aa5d1584b74b104467528a195ea593194e1b200838f769b93ea2L128-L196)
* Refactored and improved FIFO push/pop logic to handle contention, overflow, and error reporting, and to track lost advertisements. (`src/common/ciot_ble_scn_base.c`)
* Changed configuration macros from `CIOT_CONFIG_BLE_SCN_ADV_FIFO_SIZE` to `CIOT_CONFIG_BLE_SCN_ADV_FIFO_ENABLED` for better feature toggling. (`src/common/ciot_ble_scn_base.c`) [[1]](diffhunk://#diff-1d56b9dfd453aa5d1584b74b104467528a195ea593194e1b200838f769b93ea2R19-R35) [[2]](diffhunk://#diff-1d56b9dfd453aa5d1584b74b104467528a195ea593194e1b200838f769b93ea2L42-R48) [[3]](diffhunk://#diff-1d56b9dfd453aa5d1584b74b104467528a195ea593194e1b200838f769b93ea2L218-R283)

**NRF UART Refactor:**

* Refactored the NRF UART implementation to use the higher-level `app_uart` driver, removing custom FIFO management and direct use of `nrf_drv_uart`. (`src/nrf/ciot_uart.c`) [[1]](diffhunk://#diff-ffccc2f85616dfd12ec2dbc6a3a71126f30eb2c9fdd873a1d71ee6f6fb46885fL16-R29) [[2]](diffhunk://#diff-ffccc2f85616dfd12ec2dbc6a3a71126f30eb2c9fdd873a1d71ee6f6fb46885fR43-R48) [[3]](diffhunk://#diff-ffccc2f85616dfd12ec2dbc6a3a71126f30eb2c9fdd873a1d71ee6f6fb46885fL74-L121) [[4]](diffhunk://#diff-ffccc2f85616dfd12ec2dbc6a3a71126f30eb2c9fdd873a1d71ee6f6fb46885fL132-R98) [[5]](diffhunk://#diff-ffccc2f85616dfd12ec2dbc6a3a71126f30eb2c9fdd873a1d71ee6f6fb46885fL143-R135)
* Simplified UART event handling and error reporting by using `app_uart_evt_t` events and global instance management. (`src/nrf/ciot_uart.c`)

These changes enhance reliability, maintainability, and thread-safety for both BLE scanning and UART communication on the NRF platform.