### PR TITLE
Feat/mbus

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -13,3 +13,16 @@
 
 * Refactored the NRF UART implementation to use the higher-level `app_uart` driver, removing custom FIFO management and direct use of `nrf_drv_uart`. (`src/nrf/ciot_uart.c`) [[1]](diffhunk://#diff-ffccc2f85616dfd12ec2dbc6a3a71126f30eb2c9fdd873a1d71ee6f6fb46885fL16-R29) [[2]](diffhunk://#diff-ffccc2f85616dfd12ec2dbc6a3a71126f30eb2c9fdd873a1d71ee6f6fb46885fR43-R48) [[3]](diffhunk://#diff-ffccc2f85616dfd12ec2dbc6a3a71126f30eb2c9fdd873a1d71ee6f6fb46885fL74-L121) [[4]](diffhunk://#diff-ffccc2f85616dfd12ec2dbc6a3a71126f30eb2c9fdd873a1d71ee6f6fb46885fL132-R98) [[5]](diffhunk://#diff-ffccc2f85616dfd12ec2dbc6a3a71126f30eb2c9fdd873a1d71ee6f6fb46885fL143-R135)
 * Simplified UART event handling and error reporting by using `app_uart_evt_t` events and global instance management. (`src/nrf/ciot_uart.c`)
+
+**Modbus Server Improvements:**
+
+* Added configurable timeout macros for Modbus server read and byte timeouts in `ciot_mbus_server.h`, allowing easier adjustment of communication timeouts.
+* Added an `nmbs_initialized` flag to the `ciot_mbus_server` struct to track initialization state, supporting safer resource management.
+* Updated the `ciot_mbus_server_start` function to return errors from `ciot_uart_start` using `CIOT_ERR_RETURN`, improving error propagation.
+* Implemented the `ciot_mbus_server_stop` function to properly stop the UART connection, reset the Modbus server state, and send a stopped event, replacing the previous "not implemented" stub.
+
+**UART Handling and Logging:**
+
+* Improved UART buffer full event logging in `ciot_uart_event_handler` to include both the event size and the actual RX buffer usage, aiding in debugging buffer overflows.
+* Added a local `rx_buffer_used` variable in the UART event handler to support the improved logging.
+* Changed the `log_buffer` in `ciot_logger.c` from global to static scope for better encapsulation and to avoid namespace pollution.

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,25,0,1
+#define CIOT_VER 0,25,0,2
 
 #ifndef CIOT_CONFIG_IFACE_CFG_FILENAME_MASK
 #define CIOT_CONFIG_IFACE_CFG_FILENAME_MASK "cfg%d.dat"

--- a/include/ciot_mbus_server.h
+++ b/include/ciot_mbus_server.h
@@ -18,6 +18,14 @@
 #include "ciot_mbus.h"
 #include "nanomodbus.h"
 
+#ifndef CIOT_MBUS_SERVER_READ_TIMEOUT_MS
+#define CIOT_MBUS_SERVER_READ_TIMEOUT_MS 250
+#endif
+
+#ifndef CIOT_MBUS_SERVER_BYTE_TIMEOUT_MS
+#define CIOT_MBUS_SERVER_BYTE_TIMEOUT_MS 250
+#endif
+
 typedef struct ciot_mbus_server *ciot_mbus_server_t;
 
 typedef struct ciot_mbus_server_base

--- a/src/common/ciot_logger.c
+++ b/src/common/ciot_logger.c
@@ -31,7 +31,7 @@ typedef struct ciot_logger
 
 static ciot_logger_t logger;
 
-char log_buffer[CIOT_CONFIG_LOG_BUFFER_SIZE];
+static char log_buffer[CIOT_CONFIG_LOG_BUFFER_SIZE];
 
 static const char *ciot_log_level_to_str(ciot_log_level_t level)
 {

--- a/src/common/ciot_mbus_server.c
+++ b/src/common/ciot_mbus_server.c
@@ -22,6 +22,7 @@ struct ciot_mbus_server
 {
     ciot_mbus_server_base_t base;
     nmbs_t nmbs;
+    bool nmbs_initialized;
 };
 
 static const char *TAG = "ciot_mbus_server";
@@ -54,7 +55,7 @@ ciot_err_t ciot_mbus_server_start(ciot_mbus_server_t self, ciot_mbus_server_cfg_
 {
     CIOT_ERR_NULL_CHECK(self);
     CIOT_ERR_NULL_CHECK(cfg);
-
+    
     self->base.cfg = *cfg;
 
     nmbs_platform_conf platform_conf;
@@ -77,7 +78,7 @@ ciot_err_t ciot_mbus_server_start(ciot_mbus_server_t self, ciot_mbus_server_cfg_
     case CIOT_MBUS_SERVER_CFG_RTU_TAG:
         platform_conf.transport = NMBS_TRANSPORT_RTU;
         if(cfg->rtu.has_uart) {
-            ciot_uart_start((ciot_uart_t)self->base.conn, &cfg->rtu.uart);
+            CIOT_ERR_RETURN(ciot_uart_start((ciot_uart_t)self->base.conn, &cfg->rtu.uart));
         }
         break;
     case CIOT_MBUS_SERVER_CFG_TCP_TAG:
@@ -105,7 +106,19 @@ ciot_err_t ciot_mbus_server_start(ciot_mbus_server_t self, ciot_mbus_server_cfg_
 ciot_err_t ciot_mbus_server_stop(ciot_mbus_server_t self)
 {
     CIOT_ERR_NULL_CHECK(self);
-    return CIOT_ERR_NOT_IMPLEMENTED;
+
+    if (self->base.cfg.which_type == CIOT_MBUS_SERVER_CFG_RTU_TAG)
+    {
+        CIOT_ERR_RETURN(ciot_uart_stop((ciot_uart_t)self->base.conn));
+    }
+
+    memset(&self->nmbs, 0, sizeof(self->nmbs));
+    self->nmbs_initialized = false;
+    self->base.status.state = CIOT_MBUS_SERVER_STATE_STOPPED;
+    self->base.status.error = CIOT_ERR_OK;
+    ciot_iface_send_event_type(&self->base.iface, CIOT_EVENT_TYPE_STOPPED);
+
+    return CIOT_ERR_OK;
 }
 
 ciot_err_t ciot_mbus_server_task(ciot_mbus_server_t self)

--- a/src/esp32/ciot_uart.c
+++ b/src/esp32/ciot_uart.c
@@ -253,7 +253,7 @@ static void ciot_uart_event_handler(ciot_uart_t self, uart_event_t *event)
         xQueueReset(self->queue);
         break;
     case UART_BUFFER_FULL:
-        uart_get_buffered_data_len(base->cfg.num, &rx_buffer_used)
+        uart_get_buffered_data_len(base->cfg.num, &rx_buffer_used);
         ESP_LOGE(TAG,
                  "UART_BUFFER_FULL[%ld]: event_size=%d, rx_used=%lu/%d",
                  base->cfg.num,

--- a/src/esp32/ciot_uart.c
+++ b/src/esp32/ciot_uart.c
@@ -233,6 +233,7 @@ static void ciot_uart2_task(void *args)
 static void ciot_uart_event_handler(ciot_uart_t self, uart_event_t *event)
 {
     ciot_uart_base_t *base = &self->base;
+    size_t rx_buffer_used = 0;
 
     switch (event->type)
     {
@@ -252,7 +253,13 @@ static void ciot_uart_event_handler(ciot_uart_t self, uart_event_t *event)
         xQueueReset(self->queue);
         break;
     case UART_BUFFER_FULL:
-        ESP_LOGE(TAG, "UART_BUFFER_FULL[%ld]: %d", base->cfg.num, event->size);
+        uart_get_buffered_data_len(base->cfg.num, &rx_buffer_used)
+        ESP_LOGE(TAG,
+                 "UART_BUFFER_FULL[%ld]: event_size=%d, rx_used=%lu/%d",
+                 base->cfg.num,
+                 event->size,
+                 (unsigned long)rx_buffer_used,
+                 CIOT_CONFIG_UART_RX_BUF_SIZE);
         base->status.error = CIOT_UART_ERROR_BUFFER_FULL;
         uart_flush_input(base->cfg.num);
         xQueueReset(self->queue);


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the Modbus server and UART code, focusing on error handling, resource management, and logging clarity. The main changes include adding timeout configuration macros, enhancing the Modbus server's stop logic, improving UART buffer full event logging, and refining variable scoping.

**Modbus Server Improvements:**
* Added configurable timeout macros for Modbus server read and byte timeouts in `ciot_mbus_server.h`, allowing easier adjustment of communication timeouts.
* Added an `nmbs_initialized` flag to the `ciot_mbus_server` struct to track initialization state, supporting safer resource management.
* Updated the `ciot_mbus_server_start` function to return errors from `ciot_uart_start` using `CIOT_ERR_RETURN`, improving error propagation.
* Implemented the `ciot_mbus_server_stop` function to properly stop the UART connection, reset the Modbus server state, and send a stopped event, replacing the previous "not implemented" stub.

**UART Handling and Logging:**
* Improved UART buffer full event logging in `ciot_uart_event_handler` to include both the event size and the actual RX buffer usage, aiding in debugging buffer overflows.
* Added a local `rx_buffer_used` variable in the UART event handler to support the improved logging.
* Changed the `log_buffer` in `ciot_logger.c` from global to static scope for better encapsulation and to avoid namespace pollution.