### PR TITLE
refactor(ciot_mbus_server): update timeout function calls for clarity

### DIFF
--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,25,0,2
+#define CIOT_VER 0,25,0,3
 
 #ifndef CIOT_CONFIG_IFACE_CFG_FILENAME_MASK
 #define CIOT_CONFIG_IFACE_CFG_FILENAME_MASK "cfg%d.dat"

--- a/src/common/ciot_mbus_server.c
+++ b/src/common/ciot_mbus_server.c
@@ -72,8 +72,8 @@ ciot_err_t ciot_mbus_server_start(ciot_mbus_server_t self, ciot_mbus_server_cfg_
     callbacks.read_holding_registers = ciot_mbus_server_read_holding_registers;
     callbacks.write_multiple_registers = ciot_mbus_server_write_multiple_registers;
 
-    nmbs_set_read_timeout_ms(&self->nmbs, CIOT_MBUS_SERVER_READ_TIMEOUT_MS);
-    nmbs_set_byte_timeout_ms(&self->nmbs, CIOT_MBUS_SERVER_BYTE_TIMEOUT_MS);
+    nmbs_set_read_timeout(&self->nmbs, CIOT_MBUS_SERVER_READ_TIMEOUT_MS);
+    nmbs_set_byte_timeout(&self->nmbs, CIOT_MBUS_SERVER_BYTE_TIMEOUT_MS);
 
     nmbs_error err = 0;
     switch (cfg->which_type)


### PR DESCRIPTION
This pull request updates how timeout values are set in the Modbus server initialization to use functions that no longer require explicit time units in their names, reflecting an API change.

**Modbus server timeout configuration:**

* Replaced calls to `nmbs_set_read_timeout_ms` and `nmbs_set_byte_timeout_ms` with `nmbs_set_read_timeout` and `nmbs_set_byte_timeout` in `ciot_mbus_server_start`, aligning with the updated API.