### PR TITLE
Feat/ciot core

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -26,3 +26,7 @@
 * Improved UART buffer full event logging in `ciot_uart_event_handler` to include both the event size and the actual RX buffer usage, aiding in debugging buffer overflows.
 * Added a local `rx_buffer_used` variable in the UART event handler to support the improved logging.
 * Changed the `log_buffer` in `ciot_logger.c` from global to static scope for better encapsulation and to avoid namespace pollution.
+
+**Core event handling improvements:**
+
+* [`src/core/ciot.c`](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10R593-L603): Moved the check for `CIOT_EVENT_TYPE_MSG` and the core's started state earlier in the `ciot_iface_event_handler` function, replacing a previous error log with a debug log and ensuring the function returns early with `CIOT_ERR_BUSY` if the core is not started. This prevents further processing of message events when the core is not ready.

--- a/include/ciot.h
+++ b/include/ciot.h
@@ -33,7 +33,7 @@
 #warning "Target undefined."
 #endif
 
-#define CIOT_VER 0,25,0,3
+#define CIOT_VER 0,25,0,4
 
 #ifndef CIOT_CONFIG_IFACE_CFG_FILENAME_MASK
 #define CIOT_CONFIG_IFACE_CFG_FILENAME_MASK "cfg%d.dat"

--- a/src/core/ciot.c
+++ b/src/core/ciot.c
@@ -590,17 +590,17 @@ static ciot_err_t ciot_iface_event_handler(ciot_iface_t *sender, ciot_event_t *e
         }
     }
 
+    if (event->type == CIOT_EVENT_TYPE_MSG && self->status.state != CIOT_STATE_STARTED)
+    {
+        CIOT_LOGD(TAG, "ciot core is not started");
+        return CIOT_ERR_BUSY;
+    }
+    
     receiver->event = *event;
     receiver->sender = sender;
     
     if (event->type == CIOT_EVENT_TYPE_MSG)
     {
-        if (self->status.state != CIOT_STATE_STARTED)
-        {
-            CIOT_LOGE(TAG, "ciot core is not started");
-            return CIOT_ERR_BUSY;
-        }
-
         CIOT_ERR_RETURN(ciot_bytes_received(self, sender, event->raw.bytes, event->raw.size));
 
 #if CIOT_CONFIG_FEATURE_LOG == 1


### PR DESCRIPTION
This pull request introduces a minor version update and improves event handling in the CIOT core. The main focus is on ensuring that message events are only processed when the core is in the started state, with clearer logging and early returns to prevent unnecessary processing.

Version update:

* [`include/ciot.h`](diffhunk://#diff-e3a87c483eaad2e3f831ea32fa5bb0c2538d10b268422ac8bf3e6da43110f554L36-R36): Bumped the `CIOT_VER` version macro from `0,25,0,3` to `0,25,0,4`.

Core event handling improvements:

* [`src/core/ciot.c`](diffhunk://#diff-ac3505c8e7850d45dfcfdd990afb140a041683f93b640fc2b17a8e05bdd30c10R593-L603): Moved the check for `CIOT_EVENT_TYPE_MSG` and the core's started state earlier in the `ciot_iface_event_handler` function, replacing a previous error log with a debug log and ensuring the function returns early with `CIOT_ERR_BUSY` if the core is not started. This prevents further processing of message events when the core is not ready.